### PR TITLE
docs: show overlay result in demo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # avplumber - make your own libav processing graph
 
-[![Sixteen colored and labeled layers composed by overlay_many_cuda](demos/cuda-overlay/docs/overlay-many-cuda-16-input-1080p.png)](demos/cuda-overlay/README.md)
-
-One 1080p base and 15 transparent, labeled overlays composed on the GPU by
-`overlay_many_cuda`. [Run the verified CUDA overlay demo](demos/cuda-overlay/README.md).
-
 avplumber is a graph-based real-time processing framework. Graph can be reconfigured on the fly using a text API. Most nodes are based on FFmpeg's libavcodec, libavformat & libavfilter. You can create entire transcoding & filtering chain in it, replacing FFmpeg in many use cases.
 
 avplumber was created because we were experienced with FFmpeg and wanted to have its features, plus more flexibility. For example, it is possible to:

--- a/demos/cuda-overlay/README.md
+++ b/demos/cuda-overlay/README.md
@@ -1,5 +1,10 @@
 # CUDA Overlay Demo — deterministic `overlay_many_cuda` validation
 
+![Sixteen colored and labeled layers composed by overlay_many_cuda](docs/overlay-many-cuda-16-input-1080p.png)
+
+One 1080p base and 15 transparent, labeled overlays composed on the GPU by
+`overlay_many_cuda`.
+
 Build the repository's FFmpeg patch stack on public FFmpeg `n7.1.5`, run the
 patched `overlay_many_cuda` through a purpose-built PyPlumber graph, and compare
 every output plane against an independent CPU reference.


### PR DESCRIPTION
Place the verified lossless 1920x1080 CUDA output directly beneath the CUDA overlay demo title, where it belongs.

Also remove the image and caption from the root README. The PNG was generated and validated in PR #20.