### PR TITLE
ocr: add two-stage scoreboard runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,10 +174,13 @@ NODES_SRC += $(SRCDIR)/nodes/neural_net/common/infer_trt_base.cpp
 NODES_SRC += $(SRCDIR)/nodes/neural_net/yolo/infer_yolo.cpp
 NODES_SRC += $(SRCDIR)/nodes/neural_net/rtdetr/infer_rtdetr.cpp
 NODES_SRC += $(SRCDIR)/nodes/neural_net/ocr/doctr_ocr.cpp
+NODES_SRC += $(SRCDIR)/nodes/neural_net/ocr/ocr_trt_runner.cpp
+NODES_SRC += $(SRCDIR)/nodes/neural_net/ocr/doctr_recognizer.cpp
+NODES_SRC += $(SRCDIR)/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
 NODES_SRC += $(SRCDIR)/nodes/neural_net/scene_cut/cuda_infer_scene_cut_onnx.cpp
 $(eval $(call ptx_kernel,$(SRCDIR)/nodes/neural_net/preprocess/nv12_to_nchw.cu,avpl_yolo_preprocess_ptx,objs/src/nodes/neural_net/common/infer_trt_base.o objs/src/nodes/neural_net/yolo/infer_yolo.o))
 $(eval $(call ptx_kernel,$(SRCDIR)/nodes/neural_net/preprocess/mask_assemble.cu,avpl_yolo_mask_assemble_ptx,objs/src/nodes/neural_net/common/infer_trt_base.o objs/src/nodes/neural_net/yolo/infer_yolo.o))
-$(eval $(call ptx_kernel,$(SRCDIR)/nodes/neural_net/preprocess/nv12_doctr_preprocess.cu,avpl_doctr_preprocess_ptx,objs/src/nodes/neural_net/ocr/doctr_ocr.o))
+$(eval $(call ptx_kernel,$(SRCDIR)/nodes/neural_net/preprocess/nv12_doctr_preprocess.cu,avpl_doctr_preprocess_ptx,objs/src/nodes/neural_net/ocr/doctr_ocr.o objs/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.o))
 $(eval $(call ptx_kernel,$(SRCDIR)/nodes/neural_net/scene_cut/cuda_infer_scene_cut_onnx.cu,avpl_scene_cut_onnx_ptx,objs/src/nodes/neural_net/scene_cut/cuda_infer_scene_cut_onnx.o))
 $(eval $(call ptx_kernel,$(SRCDIR)/nodes/neural_net/tracking/tracknet_ball_preprocess.cu,avpl_tracknet_ball_preprocess_ptx,objs/src/nodes/neural_net/tracking/tracknet_ball.o))
 endif

--- a/pyplumber/node.py
+++ b/pyplumber/node.py
@@ -208,6 +208,10 @@ class DoctrOcr(InternalNode):
     TYPE = "doctr_ocr"
 
 
+class ScoreboardTwoStageOcr(InternalNode):
+    TYPE = "scoreboard_two_stage_ocr"
+
+
 class JoinMetadata(InternalNode):
     TYPE = "join_metadata"
 

--- a/src/nodes/neural_net/common/infer_trt_base.hpp
+++ b/src/nodes/neural_net/common/infer_trt_base.hpp
@@ -108,7 +108,6 @@ inline size_t elementSize(nvinfer1::DataType dt) {
     switch (dt) {
         case nvinfer1::DataType::kFLOAT: return 4;
         case nvinfer1::DataType::kHALF: return 2;
-        case nvinfer1::DataType::kUINT8: return 1;
         case nvinfer1::DataType::kINT8: return 1;
         case nvinfer1::DataType::kUINT8: return 1;
         case nvinfer1::DataType::kINT32: return 4;

--- a/src/nodes/neural_net/common/infer_trt_base.hpp
+++ b/src/nodes/neural_net/common/infer_trt_base.hpp
@@ -108,6 +108,7 @@ inline size_t elementSize(nvinfer1::DataType dt) {
     switch (dt) {
         case nvinfer1::DataType::kFLOAT: return 4;
         case nvinfer1::DataType::kHALF: return 2;
+        case nvinfer1::DataType::kUINT8: return 1;
         case nvinfer1::DataType::kINT8: return 1;
         case nvinfer1::DataType::kUINT8: return 1;
         case nvinfer1::DataType::kINT32: return 4;

--- a/src/nodes/neural_net/ocr/doctr_ocr.cpp
+++ b/src/nodes/neural_net/ocr/doctr_ocr.cpp
@@ -1,5 +1,7 @@
 #include "../../node_common.hpp"
 #include "../common/infer_trt_base.hpp"
+#include "doctr_recognizer.hpp"
+#include "ocr_trt_runner.hpp"
 
 extern "C" {
 #include <libavutil/dict.h>
@@ -15,7 +17,6 @@ extern "C" {
 #include <cmath>
 #include <cstdint>
 #include <deque>
-#include <fstream>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -25,40 +26,6 @@ namespace {
 constexpr int kDetBatch = 4;
 constexpr int kDetH = 200;
 constexpr int kDetW = 768;
-constexpr int kRecH = 32;
-constexpr int kRecW = 128;
-
-// doctr's VOCABS["french"], verbatim and EXACTLY 126 codepoints. This is the vocab
-// the recognizer ONNX (PARSeq) was trained/exported with: its inference head emits
-// 127 classes = these 126 chars (indices 0..125) plus <eos> at index 126. The vocab
-// must match byte-for-byte or the tail indices (currency/accents) decode to the wrong
-// glyph and the <eos> stop index drifts. NOTE: doctr's french has NO space between the
-// "~" punctuation block and the "°" currency block — an extra space here shifts every
-// later index by one and makes <eos> unreachable (the whole string decodes as garbage
-// after the real word). Keep this in sync with doctr.datasets.VOCABS["french"].
-const std::string kFrenchVocab =
-    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    R"(!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~)"
-    "°£€¥¢฿"
-    "àâéèêëîïôùûüçÀÂÉÈÊËÎÏÔÙÛÜÇ";
-
-std::vector<std::string> splitUtf8Codepoints(const std::string& text) {
-    std::vector<std::string> out;
-    for (size_t i = 0; i < text.size();) {
-        unsigned char c = (unsigned char)text[i];
-        size_t len = 1;
-        if ((c & 0x80) == 0x00) len = 1;
-        else if ((c & 0xE0) == 0xC0) len = 2;
-        else if ((c & 0xF0) == 0xE0) len = 3;
-        else if ((c & 0xF8) == 0xF0) len = 4;
-        if (i + len > text.size()) break;
-        out.push_back(text.substr(i, len));
-        i += len;
-    }
-    return out;
-}
-
-const std::vector<std::string> kFrenchTokens = splitUtf8Codepoints(kFrenchVocab);
 
 struct Region {
     int x = 0, y = 0, w = 0, h = 0;
@@ -149,116 +116,6 @@ int autoRegionHeight(int W, int H) {
     int h = (int)std::lround((double)region_w * (double)kDetH / (double)kDetW);
     return std::max(1, std::min(h, H));
 }
-
-class DoctrLogger : public nvinfer1::ILogger {
-public:
-    void log(Severity severity, const char* msg) noexcept override {
-        if (severity <= Severity::kWARNING) logstream << "doctr_ocr tensorrt: " << (msg ? msg : "");
-    }
-};
-
-struct TrtRunner {
-    std::string path;
-    std::string input_name;
-    std::vector<std::string> tensor_names;
-    std::vector<CUdeviceptr> ptrs;
-    std::vector<size_t> bytes;
-    std::vector<float> output;
-    int input_index = -1;
-    int output_index = -1;
-    int n = 0, c = 0, h = 0, w = 0;
-    int n_classes = 0;
-    nvinfer1::IRuntime* runtime = nullptr;
-    nvinfer1::ICudaEngine* engine = nullptr;
-    nvinfer1::IExecutionContext* ctx = nullptr;
-    CUstream stream = nullptr;
-
-    void cleanup() {
-        if (stream) { CUDA_CHECK_CU(cuStreamSynchronize(stream)); CUDA_CHECK_CU(cuStreamDestroy(stream)); stream = nullptr; }
-        for (CUdeviceptr p : ptrs) if (p) CUDA_CHECK_CU(cuMemFree(p));
-        ptrs.clear(); bytes.clear(); tensor_names.clear(); output.clear();
-        if (ctx) { delete ctx; ctx = nullptr; }
-        if (engine) { delete engine; engine = nullptr; }
-        if (runtime) { delete runtime; runtime = nullptr; }
-    }
-
-    bool init(DoctrLogger& logger, int want_n, int want_c, int want_h, int want_w) {
-        std::ifstream f(path, std::ios::binary);
-        if (!f) { logstream << "doctr_ocr: cannot open engine " << path; return false; }
-        f.seekg(0, std::ios::end);
-        std::streamsize sz = f.tellg();
-        f.seekg(0, std::ios::beg);
-        std::vector<char> blob((size_t)sz);
-        if (sz <= 0 || !f.read(blob.data(), sz)) { logstream << "doctr_ocr: failed reading engine " << path; return false; }
-        runtime = nvinfer1::createInferRuntime(logger);
-        if (!runtime) return false;
-        engine = runtime->deserializeCudaEngine(blob.data(), blob.size());
-        if (!engine) return false;
-        ctx = engine->createExecutionContext();
-        if (!ctx) return false;
-        if (CUDA_CHECK_CU(cuStreamCreate(&stream, 0))) return false;
-
-        int nb = engine->getNbIOTensors();
-        ptrs.assign((size_t)nb, 0);
-        bytes.assign((size_t)nb, 0);
-        for (int i = 0; i < nb; ++i) {
-            std::string name = engine->getIOTensorName(i);
-            tensor_names.push_back(name);
-            if (engine->getTensorIOMode(name.c_str()) == nvinfer1::TensorIOMode::kINPUT) {
-                input_index = i;
-                input_name = name;
-                nvinfer1::Dims4 dims(want_n, want_c, want_h, want_w);
-                ctx->setInputShape(name.c_str(), dims);
-            }
-        }
-        for (int i = 0; i < nb; ++i) {
-            const std::string& name = tensor_names[(size_t)i];
-            nvinfer1::Dims dims = ctx->getTensorShape(name.c_str());
-            if (dims.nbDims <= 0) dims = engine->getTensorShape(name.c_str());
-            size_t vol = yolo_base::volume(dims);
-            size_t esz = yolo_base::elementSize(engine->getTensorDataType(name.c_str()));
-            if (vol == 0 || esz == 0) {
-                logstream << "doctr_ocr: unsupported tensor shape for " << path << " tensor=" << name;
-                return false;
-            }
-            bytes[(size_t)i] = vol * esz;
-            if (CUDA_CHECK_CU(cuMemAlloc(&ptrs[(size_t)i], bytes[(size_t)i]))) return false;
-            if (!ctx->setTensorAddress(name.c_str(), reinterpret_cast<void*>(ptrs[(size_t)i]))) return false;
-            if (engine->getTensorIOMode(name.c_str()) == nvinfer1::TensorIOMode::kOUTPUT) {
-                output_index = i;
-                output.assign(vol, 0.0f);
-            }
-        }
-        if (input_index < 0 || output_index < 0) return false;
-        // Read actual n from the bound input shape (the plan's static batch dim),
-        // not from want_n — they differ when max_boxes != plan batch size.
-        {
-            nvinfer1::Dims in_dims = ctx->getTensorShape(tensor_names[(size_t)input_index].c_str());
-            n = (in_dims.nbDims > 0) ? (int)in_dims.d[0] : want_n;
-        }
-        c = want_c; h = want_h; w = want_w;
-        // Read n_classes from the last dim of the output tensor.
-        {
-            nvinfer1::Dims out_dims = ctx->getTensorShape(tensor_names[(size_t)output_index].c_str());
-            n_classes = (out_dims.nbDims > 0) ? (int)out_dims.d[out_dims.nbDims - 1] : 0;
-        }
-        logstream << "doctr_ocr: loaded engine=" << path << " input=" << n << "x" << c << "x" << h << "x" << w
-                  << " n_classes=" << n_classes;
-        return true;
-    }
-
-    CUdeviceptr inputPtr() const { return ptrs[(size_t)input_index]; }
-
-    bool infer() {
-        if (!ctx->enqueueV3(reinterpret_cast<cudaStream_t>(stream))) {
-            logstream << "doctr_ocr: enqueue failed for " << path;
-            return false;
-        }
-        if (CUDA_CHECK_CU(cuMemcpyDtoHAsync(output.data(), ptrs[(size_t)output_index], bytes[(size_t)output_index], stream))) return false;
-        if (CUDA_CHECK_CU(cuStreamSynchronize(stream))) return false;
-        return true;
-    }
-};
 
 std::vector<uint8_t> morphOpen3x3(const std::vector<uint8_t>& src, int W, int H) {
     std::vector<uint8_t> er(src.size(), 0), out(src.size(), 0);
@@ -360,44 +217,6 @@ std::vector<TextBox> boxesFromDetector(const std::vector<float>& logits, const s
     return boxes;
 }
 
-std::pair<std::string, float> decodeParseq(const float* logits, int steps, int classes) {
-    std::string text;
-    float conf_sum = 0.0f;
-    int conf_n = 0;
-    // PARSeq inference head emits |vocab| + 1 classes: vocab tokens at indices
-    // [0, eos) and the <eos> stop token at index eos == |vocab|. Decoding stops at
-    // the first <eos>; anything after it is padding the model is free to fill with
-    // noise (this is what produced the repeated-glyph garbage tail when eos was
-    // mis-set to an unreachable index). One-time guard: if the runtime class count
-    // disagrees with the vocab, the vocab is out of sync with the engine.
-    const int eos = (int)kFrenchTokens.size();
-    if (classes != eos + 1) {
-        static bool warned = false;
-        if (!warned) {
-            warned = true;
-            logstream << "DoctrOcr: recognizer emits " << classes << " classes but vocab "
-                      << "implies " << (eos + 1) << " (|vocab|=" << eos << " + <eos>); "
-                      << "kFrenchVocab is out of sync with the model — decode will be wrong";
-        }
-    }
-    for (int t = 0; t < steps; ++t) {
-        const float* row = logits + t * classes;
-        int best = 0;
-        float maxv = row[0];
-        for (int c = 1; c < classes; ++c) if (row[c] > maxv) { maxv = row[c]; best = c; }
-        float denom = 0.0f;
-        for (int c = 0; c < classes; ++c) denom += std::exp(row[c] - maxv);
-        float prob = denom > 0.0f ? 1.0f / denom : 0.0f;
-        if (best == eos) break;
-        if (best >= 0 && best < eos) {
-            text += kFrenchTokens[(size_t)best];
-            conf_sum += prob;
-            ++conf_n;
-        }
-    }
-    return {text, conf_n ? conf_sum / (float)conf_n : 0.0f};
-}
-
 } // namespace
 
 class DoctrOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public ReportsFinishByFlag {
@@ -433,9 +252,9 @@ class DoctrOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public Reports
     bool last_context_reinit_ = false;
     bool last_context_match_ = false;
     int64_t last_context_init_ms_ = 0;
-    DoctrLogger logger_;
-    TrtRunner det_;
-    TrtRunner rec_;
+    ocr::TrtLogger logger_;
+    ocr::TrtRunner det_;
+    ocr::DoctrRecognizer recognizer_;
 
     bool frameCudaContext(const av::VideoFrame& frm, CUcontext& ctx, AVCUDADeviceContext** dev_ctx = nullptr) const {
         ctx = nullptr;
@@ -466,7 +285,7 @@ class DoctrOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public Reports
     void cleanupContextBoundState() {
         if (cu_ctx_) CUDA_CHECK_CU(cuCtxSetCurrent(cu_ctx_));
         det_.cleanup();
-        rec_.cleanup();
+        recognizer_.cleanup();
         if (d_boxes_) { CUDA_CHECK_CU(cuMemFree(d_boxes_)); d_boxes_ = 0; }
         if (preprocess_module_) { CUDA_CHECK_CU(cuModuleUnload(preprocess_module_)); preprocess_module_ = nullptr; }
         cuda_dev_ctx_ = nullptr;
@@ -482,11 +301,11 @@ class DoctrOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public Reports
         const std::string ptx(avpl_doctr_preprocess_ptx, avpl_doctr_preprocess_ptx + avpl_doctr_preprocess_ptx_len);
         if (CUDA_CHECK_CU(cuModuleLoadDataEx(&preprocess_module_, ptx.c_str(), 0, nullptr, nullptr))) return false;
         if (CUDA_CHECK_CU(cuModuleGetFunction(&preprocess_kernel_, preprocess_module_, "kNV12_doctr_crop_resize_pad_f32"))) return false;
-        det_.path = detector_engine_;
-        rec_.path = recognizer_engine_;
-        if (!det_.init(logger_, kDetBatch, 3, kDetH, kDetW)) return false;
-        if (!rec_.init(logger_, max_boxes_, 3, kRecH, kRecW)) return false;
-        if (CUDA_CHECK_CU(cuMemAlloc(&d_boxes_, (size_t)rec_.n * 4 * sizeof(int)))) return false;
+        det_.init(logger_, detector_engine_,
+                  ocr::TensorContract{"", nvinfer1::DataType::kFLOAT, {kDetBatch, 3, kDetH, kDetW}},
+                  ocr::TensorContract{"", nvinfer1::DataType::kFLOAT, {}});
+        recognizer_.init(logger_, preprocess_module_, recognizer_engine_, max_boxes_);
+        if (CUDA_CHECK_CU(cuMemAlloc(&d_boxes_, (size_t)kDetBatch * 4 * sizeof(int)))) return false;
         initialized_ = true;
         return true;
     }
@@ -570,15 +389,15 @@ class DoctrOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public Reports
         return initInCurrentContext();
     }
 
-    void launchPreprocess(const av::VideoFrame& frm, TrtRunner& runner, const std::vector<int>& boxes,
+    void launchPreprocess(const av::VideoFrame& frm, ocr::TrtRunner& runner, const std::vector<int>& boxes,
                           float mr, float mg, float mb, float sr, float sg, float sb) {
-        CUDA_CHECK_CU(cuMemcpyHtoDAsync(d_boxes_, boxes.data(), boxes.size() * sizeof(int), runner.stream));
+        CUDA_CHECK_CU(cuMemcpyHtoDAsync(d_boxes_, boxes.data(), boxes.size() * sizeof(int), runner.stream()));
         CUdeviceptr dY = (CUdeviceptr)(uintptr_t)frm.raw()->data[0];
         CUdeviceptr dUV = (CUdeviceptr)(uintptr_t)frm.raw()->data[1];
         int pitchY = frm.raw()->linesize[0];
         int pitchUV = frm.raw()->linesize[1];
         CUdeviceptr out = runner.inputPtr();
-        int batch = runner.n, h = runner.h, w = runner.w;
+        int batch = runner.inputDim(0), h = runner.inputDim(2), w = runner.inputDim(3);
         void* args[] = {
             &dY, &pitchY, &dUV, &pitchUV, &out, &d_boxes_, &batch, &h, &w,
             &mr, &mg, &mb, &sr, &sg, &sb
@@ -586,7 +405,7 @@ class DoctrOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public Reports
         unsigned int bx = 16, by = 16;
         unsigned int gx = (unsigned int)((w + (int)bx - 1) / (int)bx);
         unsigned int gy = (unsigned int)((h + (int)by - 1) / (int)by);
-        CUDA_CHECK_CU(cuLaunchKernel(preprocess_kernel_, gx, gy, (unsigned int)batch, bx, by, 1, 0, runner.stream, args, nullptr));
+        CUDA_CHECK_CU(cuLaunchKernel(preprocess_kernel_, gx, gy, (unsigned int)batch, bx, by, 1, 0, runner.stream(), args, nullptr));
     }
 
     Parameters emptyPayload(bool sampled, const std::string& reason) {
@@ -665,42 +484,34 @@ public:
             det_boxes.insert(det_boxes.end(), {regions[(size_t)i].x, regions[(size_t)i].y, regions[(size_t)i].w, regions[(size_t)i].h});
         }
         launchPreprocess(frm, det_, det_boxes, 0.798f, 0.785f, 0.772f, 0.264f, 0.2749f, 0.287f);
-        bool ok = det_.infer();
-        std::vector<TextBox> boxes = ok
-            ? boxesFromDetector(det_.output, regions, det_bin_thresh_, det_box_thresh_, edge_margin_, edge_margin_px_,
-                                rec_.n)
-            : std::vector<TextBox>();
+        det_.infer();
+        std::vector<TextBox> boxes = boxesFromDetector(
+            det_.output(), regions, det_bin_thresh_, det_box_thresh_, edge_margin_, edge_margin_px_,
+            recognizer_.batchSize());
 
         int raw_kept = (int)boxes.size();
         if (!boxes.empty()) {
-            std::vector<int> rec_boxes((size_t)rec_.n * 4, 0);
-            for (size_t i = 0; i < boxes.size() && i < (size_t)rec_.n; ++i) {
+            std::vector<ocr::PixelBox> rec_boxes;
+            rec_boxes.reserve(boxes.size());
+            for (size_t i = 0; i < boxes.size(); ++i) {
                 int x1 = std::max(0, (int)std::floor(boxes[i].x1));
                 int y1 = std::max(0, (int)std::floor(boxes[i].y1));
                 int x2 = std::min(W, (int)std::ceil(boxes[i].x2));
                 int y2 = std::min(H, (int)std::ceil(boxes[i].y2));
-                rec_boxes[i * 4 + 0] = x1;
-                rec_boxes[i * 4 + 1] = y1;
-                rec_boxes[i * 4 + 2] = std::max(1, x2 - x1);
-                rec_boxes[i * 4 + 3] = std::max(1, y2 - y1);
+                rec_boxes.push_back({x1, y1, std::max(x1 + 1, x2), std::max(y1 + 1, y2)});
             }
-            launchPreprocess(frm, rec_, rec_boxes, 0.694f, 0.695f, 0.693f, 0.299f, 0.296f, 0.301f);
-            if (rec_.infer()) {
-                const int steps = 33;
-                const int classes = (rec_.n_classes > 0)
-                    ? rec_.n_classes
-                    : ((int)kFrenchTokens.size() + 1);
-                for (size_t i = 0; i < boxes.size(); ++i) {
-                    auto decoded = decodeParseq(rec_.output.data() + i * steps * classes, steps, classes);
-                    boxes[i].text = decoded.first;
-                    boxes[i].reco_conf = decoded.second;
-                }
+            const std::vector<ocr::Recognition> recognized = recognizer_.recognize(frm, rec_boxes);
+            for (size_t i = 0; i < boxes.size(); ++i) {
+                boxes[i].text = recognized[i].text;
+                boxes[i].reco_conf = recognized[i].confidence;
             }
         }
 
         Parameters out;
         out["schema"] = "doctr_ocr_v1";
         out["ocr_sampled"] = true;
+        out["frame_width"] = frm.raw()->width;
+        out["frame_height"] = frm.raw()->height;
         out["regions"] = Parameters::array();
         for (int i = 0; i < std::min((int)regions.size(), kDetBatch); ++i) {
             Parameters r;
@@ -728,7 +539,7 @@ public:
         out["stats"] = {
             {"raw_boxes", raw_kept},
             {"recognized", recognized},
-            {"max_boxes", rec_.n},
+            {"max_boxes", recognizer_.batchSize()},
             {"sample_every_n", sample_every_n_},
             {"target_fps", target_fps_},
             {"elapsed_ms", ms}

--- a/src/nodes/neural_net/ocr/doctr_recognizer.cpp
+++ b/src/nodes/neural_net/ocr/doctr_recognizer.cpp
@@ -1,0 +1,158 @@
+#include "doctr_recognizer.hpp"
+
+#include <avcpp/av.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+constexpr int kRecH = 32;
+constexpr int kRecW = 128;
+constexpr int kRecSteps = 33;
+
+const std::string kFrenchVocab =
+    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    R"(!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~)"
+    "°£€¥¢฿"
+    "àâéèêëîïôùûüçÀÂÉÈÊËÎÏÔÙÛÜÇ";
+
+std::vector<std::string> splitUtf8Codepoints(const std::string& text) {
+    std::vector<std::string> out;
+    for (size_t i = 0; i < text.size();) {
+        const unsigned char c = (unsigned char)text[i];
+        size_t len = 1;
+        if ((c & 0xE0) == 0xC0) len = 2;
+        else if ((c & 0xF0) == 0xE0) len = 3;
+        else if ((c & 0xF8) == 0xF0) len = 4;
+        if (i + len > text.size()) break;
+        out.push_back(text.substr(i, len));
+        i += len;
+    }
+    return out;
+}
+
+const std::vector<std::string> kFrenchTokens = splitUtf8Codepoints(kFrenchVocab);
+
+ocr::Recognition decodeParseq(const float* logits, int steps, int classes) {
+    ocr::Recognition result;
+    float confidence_sum = 0.0f;
+    int confidence_count = 0;
+    const int eos = (int)kFrenchTokens.size();
+    if (classes != eos + 1) {
+        throw Error("doctr recognizer class count does not match french vocabulary");
+    }
+    for (int step = 0; step < steps; ++step) {
+        const float* row = logits + step * classes;
+        int best = 0;
+        float maximum = row[0];
+        for (int cls = 1; cls < classes; ++cls) {
+            if (row[cls] > maximum) { maximum = row[cls]; best = cls; }
+        }
+        float denominator = 0.0f;
+        for (int cls = 0; cls < classes; ++cls) denominator += std::exp(row[cls] - maximum);
+        const float probability = denominator > 0.0f ? 1.0f / denominator : 0.0f;
+        if (best == eos) break;
+        if (best >= 0 && best < eos) {
+            result.text += kFrenchTokens[(size_t)best];
+            confidence_sum += probability;
+            ++confidence_count;
+        }
+    }
+    result.confidence = confidence_count ? confidence_sum / (float)confidence_count : 0.0f;
+    return result;
+}
+
+void requireCuda(CUresult result, const char* operation) {
+    if (result == CUDA_SUCCESS) return;
+    throw Error(std::string("doctr CUDA failure in ") + operation);
+}
+
+} // namespace
+
+namespace ocr {
+
+DoctrRecognizer::~DoctrRecognizer() {
+    cleanup();
+}
+
+void DoctrRecognizer::cleanup() noexcept {
+    runner_.cleanup();
+    if (d_boxes_) {
+        cuMemFree(d_boxes_);
+        d_boxes_ = 0;
+    }
+    preprocess_kernel_ = nullptr;
+    batch_size_ = 0;
+}
+
+void DoctrRecognizer::init(TrtLogger& logger, CUmodule preprocess_module,
+                           const std::string& engine_path, int batch_size) {
+    cleanup();
+    if (batch_size <= 0) throw Error("doctr recognizer batch size must be positive");
+    requireCuda(cuModuleGetFunction(&preprocess_kernel_, preprocess_module,
+                                    "kNV12_doctr_crop_resize_pad_f32"),
+                "cuModuleGetFunction(kNV12_doctr_crop_resize_pad_f32)");
+    runner_.init(logger, engine_path,
+                 TensorContract{"", nvinfer1::DataType::kFLOAT, {batch_size, 3, kRecH, kRecW}},
+                 TensorContract{"", nvinfer1::DataType::kFLOAT,
+                                {batch_size, kRecSteps, (int64_t)kFrenchTokens.size() + 1}});
+    requireCuda(cuMemAlloc(&d_boxes_, (size_t)batch_size * 4 * sizeof(int)), "cuMemAlloc(boxes)");
+    batch_size_ = batch_size;
+}
+
+std::vector<Recognition> DoctrRecognizer::recognize(const av::VideoFrame& frame,
+                                                     const std::vector<PixelBox>& boxes) {
+    if ((int)boxes.size() > batch_size_) throw Error("doctr recognizer batch overflow");
+    if (boxes.empty()) return {};
+    std::vector<int> packed((size_t)batch_size_ * 4, 0);
+    for (size_t i = 0; i < boxes.size(); ++i) {
+        const PixelBox& box = boxes[i];
+        packed[i * 4 + 0] = box.x1;
+        packed[i * 4 + 1] = box.y1;
+        packed[i * 4 + 2] = std::max(1, box.x2 - box.x1);
+        packed[i * 4 + 3] = std::max(1, box.y2 - box.y1);
+    }
+    for (size_t i = boxes.size(); i < (size_t)batch_size_; ++i) {
+        packed[i * 4 + 2] = 1;
+        packed[i * 4 + 3] = 1;
+    }
+    requireCuda(cuMemcpyHtoDAsync(d_boxes_, packed.data(), packed.size() * sizeof(int),
+                                  runner_.stream()), "cuMemcpyHtoDAsync(boxes)");
+
+    CUdeviceptr y_plane = (CUdeviceptr)(uintptr_t)frame.raw()->data[0];
+    CUdeviceptr uv_plane = (CUdeviceptr)(uintptr_t)frame.raw()->data[1];
+    int y_pitch = frame.raw()->linesize[0];
+    int uv_pitch = frame.raw()->linesize[1];
+    CUdeviceptr output = runner_.inputPtr();
+    int batch = batch_size_;
+    int height = kRecH;
+    int width = kRecW;
+    float mean_r = 0.694f, mean_g = 0.695f, mean_b = 0.693f;
+    float std_r = 0.299f, std_g = 0.296f, std_b = 0.301f;
+    void* args[] = {
+        &y_plane, &y_pitch, &uv_plane, &uv_pitch, &output, &d_boxes_,
+        &batch, &height, &width,
+        &mean_r, &mean_g, &mean_b, &std_r, &std_g, &std_b,
+    };
+    constexpr unsigned int block_x = 16;
+    constexpr unsigned int block_y = 16;
+    const unsigned int grid_x = (unsigned int)((width + (int)block_x - 1) / (int)block_x);
+    const unsigned int grid_y = (unsigned int)((height + (int)block_y - 1) / (int)block_y);
+    requireCuda(cuLaunchKernel(preprocess_kernel_, grid_x, grid_y, (unsigned int)batch,
+                               block_x, block_y, 1, 0, runner_.stream(), args, nullptr),
+                "cuLaunchKernel(doctr preprocess)");
+    runner_.infer();
+
+    std::vector<Recognition> results;
+    results.reserve(boxes.size());
+    const int classes = (int)kFrenchTokens.size() + 1;
+    for (size_t i = 0; i < boxes.size(); ++i) {
+        results.push_back(decodeParseq(
+            runner_.output().data() + i * kRecSteps * classes, kRecSteps, classes));
+    }
+    return results;
+}
+
+} // namespace ocr

--- a/src/nodes/neural_net/ocr/doctr_recognizer.hpp
+++ b/src/nodes/neural_net/ocr/doctr_recognizer.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "ocr_trt_runner.hpp"
+
+#include <string>
+#include <vector>
+
+namespace av { class VideoFrame; }
+
+namespace ocr {
+
+struct PixelBox {
+    int x1 = 0;
+    int y1 = 0;
+    int x2 = 0;
+    int y2 = 0;
+};
+
+struct Recognition {
+    std::string text;
+    float confidence = 0.0f;
+};
+
+class DoctrRecognizer {
+public:
+    DoctrRecognizer() = default;
+    ~DoctrRecognizer();
+    DoctrRecognizer(const DoctrRecognizer&) = delete;
+    DoctrRecognizer& operator=(const DoctrRecognizer&) = delete;
+
+    void init(TrtLogger& logger, CUmodule preprocess_module,
+              const std::string& engine_path, int batch_size);
+    void cleanup() noexcept;
+    std::vector<Recognition> recognize(const av::VideoFrame& frame,
+                                       const std::vector<PixelBox>& boxes);
+    int batchSize() const { return batch_size_; }
+
+private:
+    TrtRunner runner_;
+    CUfunction preprocess_kernel_ = nullptr;
+    CUdeviceptr d_boxes_ = 0;
+    int batch_size_ = 0;
+};
+
+} // namespace ocr

--- a/src/nodes/neural_net/ocr/ocr_trt_runner.cpp
+++ b/src/nodes/neural_net/ocr/ocr_trt_runner.cpp
@@ -1,0 +1,200 @@
+#include "ocr_trt_runner.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <utility>
+
+namespace {
+
+std::string dimsString(const nvinfer1::Dims& dims) {
+    std::ostringstream out;
+    for (int i = 0; i < dims.nbDims; ++i) {
+        if (i) out << 'x';
+        out << dims.d[i];
+    }
+    return out.str();
+}
+
+bool shapeMatches(const nvinfer1::Dims& actual, const std::vector<int64_t>& expected) {
+    if (actual.nbDims != (int)expected.size()) return false;
+    for (int i = 0; i < actual.nbDims; ++i) {
+        if (actual.d[i] != expected[(size_t)i]) return false;
+    }
+    return true;
+}
+
+nvinfer1::Dims expectedDims(const std::vector<int64_t>& shape) {
+    nvinfer1::Dims dims{};
+    dims.nbDims = (int)shape.size();
+    if (dims.nbDims > nvinfer1::Dims::MAX_DIMS) {
+        throw Error("ocr TensorRT contract has too many dimensions");
+    }
+    for (int i = 0; i < dims.nbDims; ++i) dims.d[i] = shape[(size_t)i];
+    return dims;
+}
+
+void requireCuda(CUresult result, const char* operation) {
+    if (result == CUDA_SUCCESS) return;
+    const char* name = nullptr;
+    const char* description = nullptr;
+    if (cuGetErrorName) cuGetErrorName(result, &name);
+    if (cuGetErrorString) cuGetErrorString(result, &description);
+    throw Error(std::string("ocr CUDA failure in ") + operation + ": " +
+                (name ? name : "unknown") + " (" +
+                (description ? description : "no description") + ")");
+}
+
+} // namespace
+
+namespace ocr {
+
+void TrtLogger::log(Severity severity, const char* msg) noexcept {
+    if (severity <= Severity::kWARNING) {
+        logstream << "ocr tensorrt: " << (msg ? msg : "");
+    }
+}
+
+TrtRunner::~TrtRunner() {
+    cleanup();
+}
+
+void TrtRunner::cleanup() noexcept {
+    if (stream_) {
+        cuStreamSynchronize(stream_);
+        cuStreamDestroy(stream_);
+        stream_ = nullptr;
+    }
+    for (CUdeviceptr ptr : ptrs_) {
+        if (ptr) cuMemFree(ptr);
+    }
+    ptrs_.clear();
+    bytes_.clear();
+    tensor_names_.clear();
+    output_.clear();
+    input_index_ = -1;
+    output_index_ = -1;
+    input_dims_ = {};
+    if (ctx_) { delete ctx_; ctx_ = nullptr; }
+    if (engine_) { delete engine_; engine_ = nullptr; }
+    if (runtime_) { delete runtime_; runtime_ = nullptr; }
+    path_.clear();
+}
+
+void TrtRunner::init(TrtLogger& logger,
+                     const std::string& engine_path,
+                     const TensorContract& input,
+                     const TensorContract& output) {
+    cleanup();
+    path_ = engine_path;
+
+    std::ifstream file(path_, std::ios::binary);
+    if (!file) throw Error("ocr: cannot open TensorRT engine " + path_);
+    file.seekg(0, std::ios::end);
+    const std::streamsize size = file.tellg();
+    file.seekg(0, std::ios::beg);
+    if (size <= 0) throw Error("ocr: empty TensorRT engine " + path_);
+    std::vector<char> blob((size_t)size);
+    if (!file.read(blob.data(), size)) throw Error("ocr: failed reading TensorRT engine " + path_);
+
+    runtime_ = nvinfer1::createInferRuntime(logger);
+    if (!runtime_) throw Error("ocr: createInferRuntime failed for " + path_);
+    engine_ = runtime_->deserializeCudaEngine(blob.data(), blob.size());
+    if (!engine_) throw Error("ocr: deserializeCudaEngine failed for " + path_);
+    ctx_ = engine_->createExecutionContext();
+    if (!ctx_) throw Error("ocr: createExecutionContext failed for " + path_);
+    requireCuda(cuStreamCreate(&stream_, 0), "cuStreamCreate");
+
+    const int tensor_count = engine_->getNbIOTensors();
+    if (tensor_count != 2) {
+        throw Error("ocr: engine must have exactly one input and one output: " + path_);
+    }
+    ptrs_.assign((size_t)tensor_count, 0);
+    bytes_.assign((size_t)tensor_count, 0);
+    tensor_names_.reserve((size_t)tensor_count);
+
+    for (int i = 0; i < tensor_count; ++i) {
+        const std::string name = engine_->getIOTensorName(i);
+        tensor_names_.push_back(name);
+        const auto mode = engine_->getTensorIOMode(name.c_str());
+        if (mode == nvinfer1::TensorIOMode::kINPUT) {
+            if (input_index_ >= 0) throw Error("ocr: engine has multiple inputs: " + path_);
+            input_index_ = i;
+            if (!input.name.empty() && name != input.name) {
+                throw Error("ocr: input binding mismatch for " + path_ + ": expected " +
+                            input.name + ", got " + name);
+            }
+            if (engine_->getTensorDataType(name.c_str()) != input.dtype) {
+                throw Error("ocr: input dtype mismatch for " + path_ + " tensor=" + name);
+            }
+            const nvinfer1::Dims dims = expectedDims(input.shape);
+            if (!ctx_->setInputShape(name.c_str(), dims)) {
+                throw Error("ocr: setInputShape failed for " + path_ + " tensor=" + name);
+            }
+        } else if (mode == nvinfer1::TensorIOMode::kOUTPUT) {
+            if (output_index_ >= 0) throw Error("ocr: engine has multiple outputs: " + path_);
+            output_index_ = i;
+            if (!output.name.empty() && name != output.name) {
+                throw Error("ocr: output binding mismatch for " + path_ + ": expected " +
+                            output.name + ", got " + name);
+            }
+            if (engine_->getTensorDataType(name.c_str()) != output.dtype) {
+                throw Error("ocr: output dtype mismatch for " + path_ + " tensor=" + name);
+            }
+        }
+    }
+    if (input_index_ < 0 || output_index_ < 0) {
+        throw Error("ocr: engine input/output binding missing: " + path_);
+    }
+
+    input_dims_ = ctx_->getTensorShape(tensor_names_[(size_t)input_index_].c_str());
+    const nvinfer1::Dims output_dims = ctx_->getTensorShape(tensor_names_[(size_t)output_index_].c_str());
+    if (!shapeMatches(input_dims_, input.shape)) {
+        throw Error("ocr: input shape mismatch for " + path_ + ": expected " +
+                    dimsString(expectedDims(input.shape)) + ", got " + dimsString(input_dims_));
+    }
+    if (!output.shape.empty() && !shapeMatches(output_dims, output.shape)) {
+        throw Error("ocr: output shape mismatch for " + path_ + ": expected " +
+                    dimsString(expectedDims(output.shape)) + ", got " + dimsString(output_dims));
+    }
+
+    for (int i = 0; i < tensor_count; ++i) {
+        const std::string& name = tensor_names_[(size_t)i];
+        const nvinfer1::Dims dims = ctx_->getTensorShape(name.c_str());
+        const size_t volume = yolo_base::volume(dims);
+        const size_t element_size = yolo_base::elementSize(engine_->getTensorDataType(name.c_str()));
+        if (!volume || !element_size) {
+            throw Error("ocr: unsupported tensor shape or dtype for " + path_ + " tensor=" + name);
+        }
+        bytes_[(size_t)i] = volume * element_size;
+        requireCuda(cuMemAlloc(&ptrs_[(size_t)i], bytes_[(size_t)i]), "cuMemAlloc");
+        if (!ctx_->setTensorAddress(name.c_str(), reinterpret_cast<void*>(ptrs_[(size_t)i]))) {
+            throw Error("ocr: setTensorAddress failed for " + path_ + " tensor=" + name);
+        }
+    }
+    output_.assign(yolo_base::volume(output_dims), 0.0f);
+    logstream << "ocr: loaded engine=" << path_ << " input=" << dimsString(input_dims_)
+              << " output=" << dimsString(output_dims);
+}
+
+CUdeviceptr TrtRunner::inputPtr() const {
+    if (input_index_ < 0) throw Error("ocr: TensorRT input requested before initialization");
+    return ptrs_[(size_t)input_index_];
+}
+
+int TrtRunner::inputDim(size_t index) const {
+    if (index >= (size_t)input_dims_.nbDims) throw Error("ocr: TensorRT input dimension out of range");
+    return input_dims_.d[index];
+}
+
+void TrtRunner::infer() {
+    if (!ctx_ || output_index_ < 0) throw Error("ocr: TensorRT inference before initialization");
+    if (!ctx_->enqueueV3(reinterpret_cast<cudaStream_t>(stream_))) {
+        throw Error("ocr: TensorRT enqueue failed for " + path_);
+    }
+    requireCuda(cuMemcpyDtoHAsync(output_.data(), ptrs_[(size_t)output_index_],
+                                  bytes_[(size_t)output_index_], stream_),
+                "cuMemcpyDtoHAsync");
+    requireCuda(cuStreamSynchronize(stream_), "cuStreamSynchronize");
+}
+
+} // namespace ocr

--- a/src/nodes/neural_net/ocr/ocr_trt_runner.hpp
+++ b/src/nodes/neural_net/ocr/ocr_trt_runner.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "../common/infer_trt_base.hpp"
+
+#include <NvInfer.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace ocr {
+
+struct TensorContract {
+    std::string name;
+    nvinfer1::DataType dtype = nvinfer1::DataType::kFLOAT;
+    std::vector<int64_t> shape;
+};
+
+class TrtLogger : public nvinfer1::ILogger {
+public:
+    void log(Severity severity, const char* msg) noexcept override;
+};
+
+class TrtRunner {
+public:
+    TrtRunner() = default;
+    ~TrtRunner();
+    TrtRunner(const TrtRunner&) = delete;
+    TrtRunner& operator=(const TrtRunner&) = delete;
+
+    void init(TrtLogger& logger,
+              const std::string& engine_path,
+              const TensorContract& input,
+              const TensorContract& output);
+    void cleanup() noexcept;
+    void infer();
+
+    CUdeviceptr inputPtr() const;
+    CUstream stream() const { return stream_; }
+    const std::vector<float>& output() const { return output_; }
+    int inputDim(size_t index) const;
+    const std::string& path() const { return path_; }
+
+private:
+    std::string path_;
+    std::vector<std::string> tensor_names_;
+    std::vector<CUdeviceptr> ptrs_;
+    std::vector<size_t> bytes_;
+    std::vector<float> output_;
+    int input_index_ = -1;
+    int output_index_ = -1;
+    nvinfer1::Dims input_dims_{};
+    nvinfer1::IRuntime* runtime_ = nullptr;
+    nvinfer1::ICudaEngine* engine_ = nullptr;
+    nvinfer1::IExecutionContext* ctx_ = nullptr;
+    CUstream stream_ = nullptr;
+};
+
+} // namespace ocr

--- a/src/nodes/neural_net/ocr/scoreboard_box_stabilizer.hpp
+++ b/src/nodes/neural_net/ocr/scoreboard_box_stabilizer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <cstddef>
 
 namespace scoreboard_post {
 
@@ -47,28 +49,61 @@ public:
 
     Update update(const Box& current) {
         if (!valid_) {
-            value_ = current;
-            valid_ = true;
+            reset(current);
             return {value_, false, false};
         }
         if (iou(value_, current) < min_iou_) {
-            value_ = current;
+            reset(current);
             return {value_, false, true};
         }
+        const Box observation = robustObservation(current);
         value_ = {
-            blend(value_.x1, current.x1),
-            blend(value_.y1, current.y1),
-            blend(value_.x2, current.x2),
-            blend(value_.y2, current.y2),
+            blend(value_.x1, observation.x1),
+            blend(value_.y1, observation.y1),
+            blend(value_.x2, observation.x2),
+            blend(value_.y2, observation.y2),
         };
         return {value_, true, false};
     }
 
-    void clear() { valid_ = false; }
+    void clear() {
+        valid_ = false;
+        observation_count_ = 0;
+    }
     bool valid() const { return valid_; }
     const Box& value() const { return value_; }
 
 private:
+    static constexpr std::size_t kObservationWindow = 3;
+
+    static float median(float a, float b, float c) {
+        return std::max(std::min(a, b), std::min(std::max(a, b), c));
+    }
+
+    void reset(const Box& current) {
+        value_ = current;
+        observations_[0] = current;
+        observation_count_ = 1;
+        valid_ = true;
+    }
+
+    Box robustObservation(const Box& current) {
+        if (observation_count_ < kObservationWindow) {
+            observations_[observation_count_++] = current;
+        } else {
+            observations_[0] = observations_[1];
+            observations_[1] = observations_[2];
+            observations_[2] = current;
+        }
+        if (observation_count_ < kObservationWindow) return current;
+        return {
+            median(observations_[0].x1, observations_[1].x1, observations_[2].x1),
+            median(observations_[0].y1, observations_[1].y1, observations_[2].y1),
+            median(observations_[0].x2, observations_[1].x2, observations_[2].x2),
+            median(observations_[0].y2, observations_[1].y2, observations_[2].y2),
+        };
+    }
+
     float blend(float previous, float current) const {
         return previous + alpha_ * (current - previous);
     }
@@ -76,6 +111,8 @@ private:
     float alpha_;
     float min_iou_;
     Box value_;
+    std::array<Box, kObservationWindow> observations_{};
+    std::size_t observation_count_ = 0;
     bool valid_ = false;
 };
 

--- a/src/nodes/neural_net/ocr/scoreboard_box_stabilizer.hpp
+++ b/src/nodes/neural_net/ocr/scoreboard_box_stabilizer.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <algorithm>
+
+namespace scoreboard_post {
+
+struct Box {
+    float x1 = 0.0f;
+    float y1 = 0.0f;
+    float x2 = 0.0f;
+    float y2 = 0.0f;
+};
+
+inline float iou(const Box& a, const Box& b) {
+    const float x1 = std::max(a.x1, b.x1);
+    const float y1 = std::max(a.y1, b.y1);
+    const float x2 = std::min(a.x2, b.x2);
+    const float y2 = std::min(a.y2, b.y2);
+    const float intersection = std::max(0.0f, x2 - x1) * std::max(0.0f, y2 - y1);
+    const float area_a = std::max(0.0f, a.x2 - a.x1) * std::max(0.0f, a.y2 - a.y1);
+    const float area_b = std::max(0.0f, b.x2 - b.x1) * std::max(0.0f, b.y2 - b.y1);
+    const float denominator = area_a + area_b - intersection;
+    return denominator > 0.0f ? intersection / denominator : 0.0f;
+}
+
+inline float verticalIou(const Box& a, const Box& b) {
+    const float top = std::max(a.y1, b.y1);
+    const float bottom = std::min(a.y2, b.y2);
+    const float intersection = std::max(0.0f, bottom - top);
+    const float height_a = std::max(0.0f, a.y2 - a.y1);
+    const float height_b = std::max(0.0f, b.y2 - b.y1);
+    const float denominator = height_a + height_b - intersection;
+    return denominator > 0.0f ? intersection / denominator : 0.0f;
+}
+
+class BoxStabilizer {
+public:
+    struct Update {
+        Box box;
+        bool matched = false;
+        bool relocated = false;
+    };
+
+    explicit BoxStabilizer(float alpha = 0.25f, float min_iou = 0.5f)
+        : alpha_(std::clamp(alpha, 0.0f, 1.0f)),
+          min_iou_(std::clamp(min_iou, 0.0f, 1.0f)) {}
+
+    Update update(const Box& current) {
+        if (!valid_) {
+            value_ = current;
+            valid_ = true;
+            return {value_, false, false};
+        }
+        if (iou(value_, current) < min_iou_) {
+            value_ = current;
+            return {value_, false, true};
+        }
+        value_ = {
+            blend(value_.x1, current.x1),
+            blend(value_.y1, current.y1),
+            blend(value_.x2, current.x2),
+            blend(value_.y2, current.y2),
+        };
+        return {value_, true, false};
+    }
+
+    void clear() { valid_ = false; }
+    bool valid() const { return valid_; }
+    const Box& value() const { return value_; }
+
+private:
+    float blend(float previous, float current) const {
+        return previous + alpha_ * (current - previous);
+    }
+
+    float alpha_;
+    float min_iou_;
+    Box value_;
+    bool valid_ = false;
+};
+
+} // namespace scoreboard_post

--- a/src/nodes/neural_net/ocr/scoreboard_post_process.hpp
+++ b/src/nodes/neural_net/ocr/scoreboard_post_process.hpp
@@ -18,6 +18,7 @@ public:
     };
 
     Level1Update updateLevel1(const Box& current) {
+        level1_misses_ = 0;
         // Level-2 consumes a full-width strip, so Level-1 X/width variation does
         // not identify a different scoreboard. Only a move to another vertical
         // band invalidates component and temporal state.
@@ -25,13 +26,14 @@ public:
             && verticalIou(level1_.value(), current) < 0.5f;
         if (relocated) {
             level1_.clear();
-            components_.clear();
+            clearComponents();
         }
         const BoxStabilizer::Update update = level1_.update(current);
         return {update.box, relocated};
     }
 
     Box updateComponent(const std::string& label, const Box& current) {
+        component_misses_ = 0;
         auto [entry, inserted] = components_.try_emplace(label);
         (void)inserted;
         return entry->second.update(current).box;
@@ -39,10 +41,24 @@ public:
 
     void clear() {
         level1_.clear();
-        components_.clear();
+        clearComponents();
+        level1_misses_ = 0;
     }
 
-    void clearComponents() { components_.clear(); }
+    void missLevel1() {
+        ++level1_misses_;
+        if (level1_misses_ >= 2) clear();
+    }
+
+    void missComponents() {
+        ++component_misses_;
+        if (component_misses_ >= 2) clearComponents();
+    }
+
+    void clearComponents() {
+        components_.clear();
+        component_misses_ = 0;
+    }
 
     static std::array<int, 4> level2Crop(const Box& scorebug, int frame_width,
                                          int frame_height, int vertical_padding) {
@@ -61,6 +77,8 @@ private:
     // matches, smooth all four coordinates even if horizontal extent changes.
     BoxStabilizer level1_{0.25f, 0.0f};
     std::unordered_map<std::string, BoxStabilizer> components_;
+    int level1_misses_ = 0;
+    int component_misses_ = 0;
 };
 
 } // namespace scoreboard_post

--- a/src/nodes/neural_net/ocr/scoreboard_post_process.hpp
+++ b/src/nodes/neural_net/ocr/scoreboard_post_process.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "scoreboard_box_stabilizer.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+#include <unordered_map>
+
+namespace scoreboard_post {
+
+class PostProcessor {
+public:
+    struct Level1Update {
+        Box box;
+        bool relocated = false;
+    };
+
+    Level1Update updateLevel1(const Box& current) {
+        // Level-2 consumes a full-width strip, so Level-1 X/width variation does
+        // not identify a different scoreboard. Only a move to another vertical
+        // band invalidates component and temporal state.
+        const bool relocated = level1_.valid()
+            && verticalIou(level1_.value(), current) < 0.5f;
+        if (relocated) {
+            level1_.clear();
+            components_.clear();
+        }
+        const BoxStabilizer::Update update = level1_.update(current);
+        return {update.box, relocated};
+    }
+
+    Box updateComponent(const std::string& label, const Box& current) {
+        auto [entry, inserted] = components_.try_emplace(label);
+        (void)inserted;
+        return entry->second.update(current).box;
+    }
+
+    void clear() {
+        level1_.clear();
+        components_.clear();
+    }
+
+    void clearComponents() { components_.clear(); }
+
+    static std::array<int, 4> level2Crop(const Box& scorebug, int frame_width,
+                                         int frame_height, int vertical_padding) {
+        int top = std::max(
+            0, (int)std::floor(scorebug.y1) - std::max(0, vertical_padding));
+        top &= ~1;
+        int bottom = std::min(
+            frame_height,
+            (int)std::ceil(scorebug.y2) + std::max(0, vertical_padding));
+        bottom = std::min(frame_height, (bottom + 1) & ~1);
+        return {0, top, frame_width, std::max(1, bottom - top)};
+    }
+
+private:
+    // Relocation is evaluated above using vertical overlap. Once the band
+    // matches, smooth all four coordinates even if horizontal extent changes.
+    BoxStabilizer level1_{0.25f, 0.0f};
+    std::unordered_map<std::string, BoxStabilizer> components_;
+};
+
+} // namespace scoreboard_post

--- a/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
+++ b/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
@@ -473,7 +473,7 @@ public:
         launchLevel1(frame);
         Detection scoreboard;
         if (!decodeLevel1(width, height, scoreboard)) {
-            if (post_process_) post_processor_.clear();
+            if (post_process_) post_processor_.missLevel1();
             const Parameters output = emptyPayload(true, "scoreboard_not_detected");
             av_dict_set(&frame.raw()->metadata, metadata_key_.c_str(), output.dump().c_str(), 0);
             this->sink_->put(frame);
@@ -528,10 +528,9 @@ public:
         output["detections"] = Parameters::array();
         output["draw_detections"] = Parameters::array();
         if (ambiguous) {
-            if (post_process_) post_processor_.clearComponents();
+            if (post_process_) post_processor_.missComponents();
             output["reason"] = "ambiguous_multiple_games";
             for (const Detection& detection : detections) {
-                output["draw_detections"].push_back(detectionJson(detection));
                 if (post_process_) {
                     output["post_process"]["raw_level2_detections"].push_back(
                         detectionJson(detection));

--- a/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
+++ b/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
@@ -2,6 +2,7 @@
 #include "../common/infer_trt_base.hpp"
 #include "doctr_recognizer.hpp"
 #include "ocr_trt_runner.hpp"
+#include "scoreboard_post_process.hpp"
 
 extern "C" {
 #include <libavutil/dict.h>
@@ -34,9 +35,7 @@ const char* const kClassNames[kClassCount] = {
     "game_clock", "shot_clock", "quarter",
 };
 
-struct Box {
-    float x1 = 0.0f, y1 = 0.0f, x2 = 0.0f, y2 = 0.0f;
-};
+using Box = scoreboard_post::Box;
 
 struct Detection {
     Box box;
@@ -48,15 +47,7 @@ struct Detection {
 };
 
 float boxIou(const Box& a, const Box& b) {
-    const float x1 = std::max(a.x1, b.x1);
-    const float y1 = std::max(a.y1, b.y1);
-    const float x2 = std::min(a.x2, b.x2);
-    const float y2 = std::min(a.y2, b.y2);
-    const float intersection = std::max(0.0f, x2 - x1) * std::max(0.0f, y2 - y1);
-    const float area_a = std::max(0.0f, a.x2 - a.x1) * std::max(0.0f, a.y2 - a.y1);
-    const float area_b = std::max(0.0f, b.x2 - b.x1) * std::max(0.0f, b.y2 - b.y1);
-    const float denominator = area_a + area_b - intersection;
-    return denominator > 0.0f ? intersection / denominator : 0.0f;
+    return scoreboard_post::iou(a, b);
 }
 
 float centerX(const Box& box) { return (box.x1 + box.x2) * 0.5f; }
@@ -133,8 +124,10 @@ class ScoreboardTwoStageOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, p
     int edge_margin_px_ = 0;
     std::vector<float> region_x_;
     int debug_log_every_n_ = 0;
+    bool post_process_ = false;
     uint64_t frame_counter_ = 0;
     uint64_t sample_counter_ = 0;
+    scoreboard_post::PostProcessor post_processor_;
 
     std::shared_ptr<HWAccelDevice> hwaccel_;
     AVCUDADeviceContext* cuda_device_context_ = nullptr;
@@ -480,22 +473,27 @@ public:
         launchLevel1(frame);
         Detection scoreboard;
         if (!decodeLevel1(width, height, scoreboard)) {
+            if (post_process_) post_processor_.clear();
             const Parameters output = emptyPayload(true, "scoreboard_not_detected");
             av_dict_set(&frame.raw()->metadata, metadata_key_.c_str(), output.dump().c_str(), 0);
             this->sink_->put(frame);
             return;
         }
 
+        const Box raw_scoreboard_box = scoreboard.box;
+        bool level1_relocated = false;
+        if (post_process_) {
+            const auto level1_update = post_processor_.updateLevel1(scoreboard.box);
+            scoreboard.box = clampBox(level1_update.box, width, height);
+            level1_relocated = level1_update.relocated;
+        }
+        // Padding already absorbs small Level-1 jitter. Keep the current raw box for
+        // the Level-2 crop so temporal output smoothing cannot change model sampling.
+        const auto level2_crop = scoreboard_post::PostProcessor::level2Crop(
+            raw_scoreboard_box, width, height, vertical_padding_);
         int crop[4] = {
-            0,
-            std::max(0, (int)std::floor(scoreboard.box.y1) - vertical_padding_),
-            width,
-            0,
+            level2_crop[0], level2_crop[1], level2_crop[2], level2_crop[3],
         };
-        crop[1] &= ~1;
-        int crop_bottom = std::min(height, (int)std::ceil(scoreboard.box.y2) + vertical_padding_);
-        crop_bottom = std::min(height, (crop_bottom + 1) & ~1);
-        crop[3] = std::max(1, crop_bottom - crop[1]);
         launchLevel2(frame, crop);
         std::vector<Detection> detections = decodeLevel2(crop, width, height);
 
@@ -515,15 +513,29 @@ public:
             {"det_conf", scoreboard.confidence},
             {"label", "scoreboard"},
         };
+        if (post_process_) {
+            output["post_process"] = {
+                {"enabled", true},
+                {"level1_relocated", level1_relocated},
+                {"raw_level1_bbox", {raw_scoreboard_box.x1, raw_scoreboard_box.y1,
+                                      raw_scoreboard_box.x2, raw_scoreboard_box.y2}},
+                {"raw_level2_detections", Parameters::array()},
+            };
+        }
         output["level2_crop"] = {crop[0], crop[1], crop[2], crop[3]};
 
         const bool ambiguous = countClass(detections, 3) > 2 || countClass(detections, 4) > 1;
         output["detections"] = Parameters::array();
         output["draw_detections"] = Parameters::array();
         if (ambiguous) {
+            if (post_process_) post_processor_.clearComponents();
             output["reason"] = "ambiguous_multiple_games";
             for (const Detection& detection : detections) {
                 output["draw_detections"].push_back(detectionJson(detection));
+                if (post_process_) {
+                    output["post_process"]["raw_level2_detections"].push_back(
+                        detectionJson(detection));
+                }
             }
         } else {
             keepSingleton(detections, 4);
@@ -535,6 +547,15 @@ public:
             }
             keepHighestPerLabel(detections);
             recognizeText(frame, detections, width, height);
+            if (post_process_) {
+                for (Detection& detection : detections) {
+                    output["post_process"]["raw_level2_detections"].push_back(
+                        detectionJson(detection));
+                    detection.box = clampBox(
+                        post_processor_.updateComponent(detection.label, detection.box),
+                        width, height);
+                }
+            }
             std::sort(detections.begin(), detections.end(), [](const Detection& a, const Detection& b) {
                 if (a.label != b.label) return a.label < b.label;
                 return a.confidence > b.confidence;
@@ -594,6 +615,7 @@ public:
             }
         }
         if (params.count("debug_log_every_n")) result->debug_log_every_n_ = std::max(0, params["debug_log_every_n"].get<int>());
+        if (params.count("post_process")) result->post_process_ = params["post_process"].get<bool>();
         result->preinitialize();
         return result;
     }

--- a/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
+++ b/src/nodes/neural_net/ocr/scoreboard_two_stage_ocr.cpp
@@ -1,0 +1,602 @@
+#include "../../node_common.hpp"
+#include "../common/infer_trt_base.hpp"
+#include "doctr_recognizer.hpp"
+#include "ocr_trt_runner.hpp"
+
+extern "C" {
+#include <libavutil/dict.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_cuda.h>
+}
+
+#include "../../../../objs/src/nodes/neural_net/preprocess/nv12_doctr_preprocess.ptx.h"
+
+#include <NvInfer.h>
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr int kLevel1H = 384;
+constexpr int kLevel1W = 640;
+constexpr int kLevel1Rows = 300;
+constexpr int kLevel2Size = 1024;
+constexpr int kLevel2Rows = 50;
+constexpr int kClassCount = 7;
+
+const char* const kClassNames[kClassCount] = {
+    "team_name", "team_score", "team_logo", "team_name_logo_score",
+    "game_clock", "shot_clock", "quarter",
+};
+
+struct Box {
+    float x1 = 0.0f, y1 = 0.0f, x2 = 0.0f, y2 = 0.0f;
+};
+
+struct Detection {
+    Box box;
+    float confidence = 0.0f;
+    int cls = -1;
+    std::string label;
+    std::string text;
+    float recognition_confidence = 0.0f;
+};
+
+float boxIou(const Box& a, const Box& b) {
+    const float x1 = std::max(a.x1, b.x1);
+    const float y1 = std::max(a.y1, b.y1);
+    const float x2 = std::min(a.x2, b.x2);
+    const float y2 = std::min(a.y2, b.y2);
+    const float intersection = std::max(0.0f, x2 - x1) * std::max(0.0f, y2 - y1);
+    const float area_a = std::max(0.0f, a.x2 - a.x1) * std::max(0.0f, a.y2 - a.y1);
+    const float area_b = std::max(0.0f, b.x2 - b.x1) * std::max(0.0f, b.y2 - b.y1);
+    const float denominator = area_a + area_b - intersection;
+    return denominator > 0.0f ? intersection / denominator : 0.0f;
+}
+
+float centerX(const Box& box) { return (box.x1 + box.x2) * 0.5f; }
+float centerY(const Box& box) { return (box.y1 + box.y2) * 0.5f; }
+
+Box clampBox(Box box, int width, int height) {
+    box.x1 = std::clamp(box.x1, 0.0f, (float)width);
+    box.x2 = std::clamp(box.x2, 0.0f, (float)width);
+    box.y1 = std::clamp(box.y1, 0.0f, (float)height);
+    box.y2 = std::clamp(box.y2, 0.0f, (float)height);
+    return box;
+}
+
+bool validBox(const Box& box) {
+    return std::isfinite(box.x1) && std::isfinite(box.y1) &&
+           std::isfinite(box.x2) && std::isfinite(box.y2) &&
+           box.x2 > box.x1 && box.y2 > box.y1;
+}
+
+double parseFps(const std::string& fps) {
+    if (fps.empty()) return 25.0;
+    const size_t slash = fps.find('/');
+    try {
+        if (slash == std::string::npos) return std::stod(fps);
+        const double numerator = std::stod(fps.substr(0, slash));
+        const double denominator = std::stod(fps.substr(slash + 1));
+        return denominator > 0.0 ? numerator / denominator : numerator;
+    } catch (...) {
+        return 25.0;
+    }
+}
+
+void requireCuda(CUresult result, const char* operation) {
+    if (result == CUDA_SUCCESS) return;
+    const char* name = nullptr;
+    const char* description = nullptr;
+    cuGetErrorName(result, &name);
+    cuGetErrorString(result, &description);
+    throw Error(std::string("scoreboard_two_stage CUDA failure in ") + operation + ": " +
+                (name ? name : "unknown") + " (" +
+                (description ? description : "no description") + ")");
+}
+
+Parameters detectionJson(const Detection& detection) {
+    Parameters result;
+    result["bbox"] = {detection.box.x1, detection.box.y1,
+                      detection.box.x2, detection.box.y2};
+    result["det_conf"] = detection.confidence;
+    result["reco_conf"] = detection.recognition_confidence;
+    result["text"] = detection.text;
+    result["label"] = detection.label;
+    result["base_label"] = kClassNames[detection.cls];
+    result["region_id"] = 0;
+    return result;
+}
+
+} // namespace
+
+class ScoreboardTwoStageOcr : public NodeSISO<av::VideoFrame, av::VideoFrame>, public ReportsFinishByFlag {
+    std::string level1_engine_;
+    std::string level2_engine_;
+    std::string recognizer_engine_;
+    std::string metadata_key_ = "text_detections";
+    std::string node_label_ = "<unnamed>";
+    float target_fps_ = 2.0f;
+    double input_fps_ = 25.0;
+    int sample_every_n_ = 13;
+    float level1_confidence_ = 0.5f;
+    float level2_confidence_ = 0.25f;
+    float recognition_confidence_ = 0.0f;
+    int vertical_padding_ = 50;
+    int max_boxes_ = 48;
+    float edge_margin_ = 0.2f;
+    int edge_margin_px_ = 0;
+    std::vector<float> region_x_;
+    int debug_log_every_n_ = 0;
+    uint64_t frame_counter_ = 0;
+    uint64_t sample_counter_ = 0;
+
+    std::shared_ptr<HWAccelDevice> hwaccel_;
+    AVCUDADeviceContext* cuda_device_context_ = nullptr;
+    CUcontext cuda_context_ = nullptr;
+    CUmodule preprocess_module_ = nullptr;
+    CUfunction level1_preprocess_ = nullptr;
+    CUfunction level2_preprocess_ = nullptr;
+    CUdeviceptr device_box_ = 0;
+    bool initialized_ = false;
+    bool preinitialized_ = false;
+    bool frame_context_checked_ = false;
+    ocr::TrtLogger logger_;
+    ocr::TrtRunner level1_;
+    ocr::TrtRunner level2_;
+    ocr::DoctrRecognizer recognizer_;
+
+    static bool frameCudaContext(const av::VideoFrame& frame, CUcontext& context,
+                                 AVCUDADeviceContext** device_context = nullptr) {
+        context = nullptr;
+        if (device_context) *device_context = nullptr;
+        if (!frame.raw() || !frame.raw()->hw_frames_ctx || !frame.raw()->hw_frames_ctx->data) return false;
+        AVHWFramesContext* frames_context =
+            reinterpret_cast<AVHWFramesContext*>(frame.raw()->hw_frames_ctx->data);
+        if (!frames_context || !frames_context->device_ctx || !frames_context->device_ctx->hwctx) return false;
+        auto* cuda = reinterpret_cast<AVCUDADeviceContext*>(frames_context->device_ctx->hwctx);
+        if (!cuda || !cuda->cuda_ctx) return false;
+        context = cuda->cuda_ctx;
+        if (device_context) *device_context = cuda;
+        return true;
+    }
+
+    void cleanup() noexcept {
+        if (cuda_context_) cuCtxSetCurrent(cuda_context_);
+        level1_.cleanup();
+        level2_.cleanup();
+        recognizer_.cleanup();
+        if (device_box_) { cuMemFree(device_box_); device_box_ = 0; }
+        if (preprocess_module_) { cuModuleUnload(preprocess_module_); preprocess_module_ = nullptr; }
+        level1_preprocess_ = nullptr;
+        level2_preprocess_ = nullptr;
+        cuda_device_context_ = nullptr;
+        cuda_context_ = nullptr;
+        initialized_ = false;
+        preinitialized_ = false;
+        frame_context_checked_ = false;
+    }
+
+    void initInCurrentContext() {
+        if (!cuda_context_) throw Error("scoreboard_two_stage: no CUDA context");
+        requireCuda(cuCtxSetCurrent(cuda_context_), "cuCtxSetCurrent(init)");
+        const std::string ptx(avpl_doctr_preprocess_ptx,
+                              avpl_doctr_preprocess_ptx + avpl_doctr_preprocess_ptx_len);
+        requireCuda(cuModuleLoadDataEx(&preprocess_module_, ptx.c_str(), 0, nullptr, nullptr),
+                    "cuModuleLoadDataEx");
+        requireCuda(cuModuleGetFunction(&level1_preprocess_, preprocess_module_,
+                                        "kNV12_scoreboard_letterbox_f32"),
+                    "cuModuleGetFunction(level1)");
+        requireCuda(cuModuleGetFunction(&level2_preprocess_, preprocess_module_,
+                                        "kNV12_scoreboard_letterbox_u8"),
+                    "cuModuleGetFunction(level2)");
+        level1_.init(logger_, level1_engine_,
+                     ocr::TensorContract{"images", nvinfer1::DataType::kFLOAT, {1, 3, kLevel1H, kLevel1W}},
+                     ocr::TensorContract{"output0", nvinfer1::DataType::kFLOAT, {1, kLevel1Rows, 6}});
+        level2_.init(logger_, level2_engine_,
+                     ocr::TensorContract{"images_uint8", nvinfer1::DataType::kUINT8, {1, 3, kLevel2Size, kLevel2Size}},
+                     ocr::TensorContract{"output0", nvinfer1::DataType::kFLOAT, {1, kLevel2Rows, 6}});
+        recognizer_.init(logger_, preprocess_module_, recognizer_engine_, max_boxes_);
+        requireCuda(cuMemAlloc(&device_box_, 4 * sizeof(int)), "cuMemAlloc(box)");
+        initialized_ = true;
+    }
+
+    void preinitialize() {
+        if (!hwaccel_ || !hwaccel_->deviceContext() || !hwaccel_->deviceContext()->data) {
+            throw Error("scoreboard_two_stage: CUDA hwaccel is required");
+        }
+        AVHWDeviceContext* device =
+            reinterpret_cast<AVHWDeviceContext*>(hwaccel_->deviceContext()->data);
+        if (!device || device->type != AV_HWDEVICE_TYPE_CUDA || !device->hwctx) {
+            throw Error("scoreboard_two_stage: hwaccel is not CUDA");
+        }
+        cuda_device_context_ = reinterpret_cast<AVCUDADeviceContext*>(device->hwctx);
+        cuda_context_ = cuda_device_context_->cuda_ctx;
+        const auto start = std::chrono::steady_clock::now();
+        initInCurrentContext();
+        preinitialized_ = true;
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start).count();
+        logstream << "neural_preinit status=ok type=scoreboard_two_stage_ocr node="
+                  << node_label_ << " init_ms=" << elapsed;
+    }
+
+    void ensureFrameContext(const av::VideoFrame& frame) {
+        CUcontext frame_context = nullptr;
+        AVCUDADeviceContext* frame_device_context = nullptr;
+        if (!frameCudaContext(frame, frame_context, &frame_device_context)) {
+            throw Error("scoreboard_two_stage: input is not a CUDA hardware frame");
+        }
+        if (!initialized_) {
+            cuda_context_ = frame_context;
+            cuda_device_context_ = frame_device_context;
+            initInCurrentContext();
+            return;
+        }
+        if (preinitialized_ && !frame_context_checked_) {
+            if (frame_context != cuda_context_) {
+                cleanup();
+                cuda_context_ = frame_context;
+                cuda_device_context_ = frame_device_context;
+                initInCurrentContext();
+            }
+            frame_context_checked_ = true;
+        }
+        requireCuda(cuCtxSetCurrent(cuda_context_), "cuCtxSetCurrent(frame)");
+    }
+
+    void launchLevel1(const av::VideoFrame& frame) {
+        const int box[4] = {0, 0, frame.raw()->width, frame.raw()->height};
+        requireCuda(cuMemcpyHtoDAsync(device_box_, box, sizeof(box), level1_.stream()),
+                    "cuMemcpyHtoDAsync(level1 box)");
+        CUdeviceptr y = (CUdeviceptr)(uintptr_t)frame.raw()->data[0];
+        CUdeviceptr uv = (CUdeviceptr)(uintptr_t)frame.raw()->data[1];
+        int y_pitch = frame.raw()->linesize[0], uv_pitch = frame.raw()->linesize[1];
+        CUdeviceptr output = level1_.inputPtr();
+        int height = kLevel1H, width = kLevel1W;
+        float pad = 114.0f / 255.0f;
+        void* args[] = {&y, &y_pitch, &uv, &uv_pitch, &output, &device_box_, &height, &width, &pad};
+        constexpr unsigned int block = 16;
+        requireCuda(cuLaunchKernel(level1_preprocess_, (width + 15) / 16, (height + 15) / 16, 1,
+                                   block, block, 1, 0, level1_.stream(), args, nullptr),
+                    "cuLaunchKernel(level1)");
+        level1_.infer();
+    }
+
+    void launchLevel2(const av::VideoFrame& frame, const int box[4]) {
+        requireCuda(cuMemcpyHtoDAsync(device_box_, box, 4 * sizeof(int), level2_.stream()),
+                    "cuMemcpyHtoDAsync(level2 box)");
+        CUdeviceptr y = (CUdeviceptr)(uintptr_t)frame.raw()->data[0];
+        CUdeviceptr uv = (CUdeviceptr)(uintptr_t)frame.raw()->data[1];
+        int y_pitch = frame.raw()->linesize[0], uv_pitch = frame.raw()->linesize[1];
+        CUdeviceptr output = level2_.inputPtr();
+        int height = kLevel2Size, width = kLevel2Size;
+        void* args[] = {&y, &y_pitch, &uv, &uv_pitch, &output, &device_box_, &height, &width};
+        constexpr unsigned int block = 16;
+        requireCuda(cuLaunchKernel(level2_preprocess_, (width + 15) / 16, (height + 15) / 16, 1,
+                                   block, block, 1, 0, level2_.stream(), args, nullptr),
+                    "cuLaunchKernel(level2)");
+        level2_.infer();
+    }
+
+    bool selectedByRegion(const Box& box, int frame_width) const {
+        if (region_x_.size() != 2) return true;
+        const float normalized_x = centerX(box) / std::max(1.0f, (float)frame_width);
+        return normalized_x >= region_x_[0] && normalized_x < region_x_[1];
+    }
+
+    bool decodeLevel1(int frame_width, int frame_height, Detection& best) const {
+        const float scale = std::min((float)kLevel1W / frame_width, (float)kLevel1H / frame_height);
+        const int content_width = std::max(1, std::min(kLevel1W, (int)std::lround(frame_width * scale)));
+        const int content_height = std::max(1, std::min(kLevel1H, (int)std::lround(frame_height * scale)));
+        const float scale_x = (float)content_width / frame_width;
+        const float scale_y = (float)content_height / frame_height;
+        const int pad_x = (kLevel1W - content_width) / 2;
+        const int pad_y = (kLevel1H - content_height) / 2;
+        bool found = false;
+        for (int row = 0; row < kLevel1Rows; ++row) {
+            const float* item = level1_.output().data() + row * 6;
+            if (!std::isfinite(item[4]) || item[4] < level1_confidence_) continue;
+            const int cls = (int)std::lround(item[5]);
+            if (cls != 0 || (found && item[4] <= best.confidence)) continue;
+            Box box{
+                (item[0] - pad_x) / scale_x,
+                (item[1] - pad_y) / scale_y,
+                (item[2] - pad_x) / scale_x,
+                (item[3] - pad_y) / scale_y,
+            };
+            box = clampBox(box, frame_width, frame_height);
+            if (!validBox(box)) continue;
+            best = Detection{box, item[4], 0, "scoreboard", "", 0.0f};
+            found = true;
+        }
+        return found;
+    }
+
+    std::vector<Detection> decodeLevel2(const int crop[4], int frame_width, int frame_height) const {
+        const float scale = std::min((float)kLevel2Size / crop[2], (float)kLevel2Size / crop[3]);
+        const int content_width = std::max(1, std::min(kLevel2Size, (int)std::lround(crop[2] * scale)));
+        const int content_height = std::max(1, std::min(kLevel2Size, (int)std::lround(crop[3] * scale)));
+        const float scale_x = (float)content_width / crop[2];
+        const float scale_y = (float)content_height / crop[3];
+        const int pad_x = (kLevel2Size - content_width) / 2;
+        const int pad_y = (kLevel2Size - content_height) / 2;
+        std::vector<Detection> decoded;
+        for (int row = 0; row < kLevel2Rows; ++row) {
+            const float* item = level2_.output().data() + row * 6;
+            if (!std::isfinite(item[4]) || item[4] < level2_confidence_) continue;
+            const int cls = (int)std::lround(item[5]);
+            if (cls < 0 || cls >= kClassCount) continue;
+            Box box{
+                crop[0] + (item[0] * kLevel2Size - pad_x) / scale_x,
+                crop[1] + (item[1] * kLevel2Size - pad_y) / scale_y,
+                crop[0] + (item[2] * kLevel2Size - pad_x) / scale_x,
+                crop[1] + (item[3] * kLevel2Size - pad_y) / scale_y,
+            };
+            box = clampBox(box, frame_width, frame_height);
+            if (validBox(box) && selectedByRegion(box, frame_width)) {
+                decoded.push_back({box, item[4], cls, kClassNames[cls], "", 0.0f});
+            }
+        }
+        std::sort(decoded.begin(), decoded.end(), [](const Detection& a, const Detection& b) {
+            return a.confidence > b.confidence;
+        });
+        std::vector<Detection> deduplicated;
+        for (const Detection& detection : decoded) {
+            const bool duplicate = std::any_of(deduplicated.begin(), deduplicated.end(),
+                [&](const Detection& kept) {
+                    return detection.cls == kept.cls && boxIou(detection.box, kept.box) >= 0.5f;
+                });
+            if (!duplicate) deduplicated.push_back(detection);
+        }
+        return deduplicated;
+    }
+
+    static void keepSingleton(std::vector<Detection>& detections, int cls) {
+        bool kept = false;
+        detections.erase(std::remove_if(detections.begin(), detections.end(), [&](const Detection& detection) {
+            if (detection.cls != cls) return false;
+            if (!kept) { kept = true; return false; }
+            return true;
+        }), detections.end());
+    }
+
+    static int countClass(const std::vector<Detection>& detections, int cls) {
+        return (int)std::count_if(detections.begin(), detections.end(),
+                                  [&](const Detection& detection) { return detection.cls == cls; });
+    }
+
+    static void assignTeamLabels(std::vector<Detection>& detections) {
+        std::vector<const Detection*> groups;
+        for (const Detection& detection : detections) {
+            if (detection.cls == 3) groups.push_back(&detection);
+        }
+        if (groups.size() != 2) return;
+        const float dx = std::fabs(centerX(groups[0]->box) - centerX(groups[1]->box));
+        const float dy = std::fabs(centerY(groups[0]->box) - centerY(groups[1]->box));
+        if ((dx >= dy && centerX(groups[0]->box) > centerX(groups[1]->box)) ||
+            (dx < dy && centerY(groups[0]->box) > centerY(groups[1]->box))) {
+            std::swap(groups[0], groups[1]);
+        }
+        for (Detection& detection : detections) {
+            if (detection.cls > 3) continue;
+            const float x = centerX(detection.box), y = centerY(detection.box);
+            int group = -1;
+            for (int index = 0; index < 2; ++index) {
+                const Box& anchor = groups[(size_t)index]->box;
+                if (x >= anchor.x1 && x <= anchor.x2 && y >= anchor.y1 && y <= anchor.y2) {
+                    if (group >= 0) { group = -1; break; }
+                    group = index;
+                }
+            }
+            if (group >= 0) {
+                detection.label = std::string(group == 0 ? "team_a_" : "team_b_") +
+                                  std::string(kClassNames[detection.cls]).substr(5);
+            }
+        }
+    }
+
+    static void keepHighestPerLabel(std::vector<Detection>& detections) {
+        std::vector<Detection> unique;
+        unique.reserve(detections.size());
+        for (const Detection& detection : detections) {
+            const bool already_kept = std::any_of(unique.begin(), unique.end(), [&](const Detection& kept) {
+                return kept.label == detection.label;
+            });
+            if (!already_kept) unique.push_back(detection);
+        }
+        detections = std::move(unique);
+    }
+
+    void recognizeText(const av::VideoFrame& frame, std::vector<Detection>& detections,
+                       int frame_width, int frame_height) {
+        std::vector<size_t> indices;
+        std::vector<ocr::PixelBox> boxes;
+        for (size_t i = 0; i < detections.size(); ++i) {
+            const int cls = detections[i].cls;
+            if (!(cls == 0 || cls == 1 || cls == 4 || cls == 5 || cls == 6)) continue;
+            if ((int)boxes.size() >= recognizer_.batchSize()) break;
+            const Box& box = detections[i].box;
+            const float margin_x = edge_margin_ * (box.x2 - box.x1) + edge_margin_px_;
+            const float margin_y = edge_margin_ * (box.y2 - box.y1) + edge_margin_px_;
+            const int x1 = std::max(0, (int)std::floor(box.x1 - margin_x));
+            const int y1 = std::max(0, (int)std::floor(box.y1 - margin_y));
+            const int x2 = std::min(frame_width, (int)std::ceil(box.x2 + margin_x));
+            const int y2 = std::min(frame_height, (int)std::ceil(box.y2 + margin_y));
+            indices.push_back(i);
+            boxes.push_back({x1, y1, std::max(x1 + 1, x2), std::max(y1 + 1, y2)});
+        }
+        const std::vector<ocr::Recognition> results = recognizer_.recognize(frame, boxes);
+        for (size_t i = 0; i < results.size(); ++i) {
+            if (results[i].confidence >= recognition_confidence_) {
+                detections[indices[i]].text = results[i].text;
+                detections[indices[i]].recognition_confidence = results[i].confidence;
+            }
+        }
+    }
+
+    Parameters emptyPayload(bool sampled, const std::string& reason) const {
+        Parameters output;
+        output["schema"] = "scoreboard_two_stage_v1";
+        output["ocr_sampled"] = sampled;
+        output["detections"] = Parameters::array();
+        output["draw_detections"] = Parameters::array();
+        output["reason"] = reason;
+        return output;
+    }
+
+public:
+    using NodeSISO<av::VideoFrame, av::VideoFrame>::NodeSISO;
+
+    ~ScoreboardTwoStageOcr() override { cleanup(); }
+
+    void process() override {
+        av::VideoFrame frame = this->source_->get();
+        if (!frame) return;
+        ++frame_counter_;
+        const bool sampled = ((frame_counter_ - 1) % (uint64_t)std::max(1, sample_every_n_)) == 0;
+        if (!sampled) {
+            const Parameters output = emptyPayload(false, "not_sampled");
+            av_dict_set(&frame.raw()->metadata, metadata_key_.c_str(), output.dump().c_str(), 0);
+            this->sink_->put(frame);
+            return;
+        }
+        if (frame.raw()->format != AV_PIX_FMT_CUDA) {
+            throw Error("scoreboard_two_stage: expected CUDA NV12 frame");
+        }
+        const auto* frames_context = reinterpret_cast<const AVHWFramesContext*>(
+            frame.raw()->hw_frames_ctx ? frame.raw()->hw_frames_ctx->data : nullptr);
+        if (!frames_context || frames_context->sw_format != AV_PIX_FMT_NV12) {
+            throw Error("scoreboard_two_stage: expected NV12 CUDA frame storage");
+        }
+        const auto start = std::chrono::steady_clock::now();
+        ensureFrameContext(frame);
+        const int width = frame.raw()->width, height = frame.raw()->height;
+        launchLevel1(frame);
+        Detection scoreboard;
+        if (!decodeLevel1(width, height, scoreboard)) {
+            const Parameters output = emptyPayload(true, "scoreboard_not_detected");
+            av_dict_set(&frame.raw()->metadata, metadata_key_.c_str(), output.dump().c_str(), 0);
+            this->sink_->put(frame);
+            return;
+        }
+
+        int crop[4] = {
+            0,
+            std::max(0, (int)std::floor(scoreboard.box.y1) - vertical_padding_),
+            width,
+            0,
+        };
+        crop[1] &= ~1;
+        int crop_bottom = std::min(height, (int)std::ceil(scoreboard.box.y2) + vertical_padding_);
+        crop_bottom = std::min(height, (crop_bottom + 1) & ~1);
+        crop[3] = std::max(1, crop_bottom - crop[1]);
+        launchLevel2(frame, crop);
+        std::vector<Detection> detections = decodeLevel2(crop, width, height);
+
+        Parameters output;
+        output["schema"] = "scoreboard_two_stage_v1";
+        output["ocr_sampled"] = true;
+        output["frame_width"] = width;
+        output["frame_height"] = height;
+        output["regions"] = Parameters::array({{
+            {"id", 0},
+            {"bbox", {scoreboard.box.x1, scoreboard.box.y1,
+                      scoreboard.box.x2 - scoreboard.box.x1,
+                      scoreboard.box.y2 - scoreboard.box.y1}},
+        }});
+        output["level1_detection"] = {
+            {"bbox", {scoreboard.box.x1, scoreboard.box.y1, scoreboard.box.x2, scoreboard.box.y2}},
+            {"det_conf", scoreboard.confidence},
+            {"label", "scoreboard"},
+        };
+        output["level2_crop"] = {crop[0], crop[1], crop[2], crop[3]};
+
+        const bool ambiguous = countClass(detections, 3) > 2 || countClass(detections, 4) > 1;
+        output["detections"] = Parameters::array();
+        output["draw_detections"] = Parameters::array();
+        if (ambiguous) {
+            output["reason"] = "ambiguous_multiple_games";
+            for (const Detection& detection : detections) {
+                output["draw_detections"].push_back(detectionJson(detection));
+            }
+        } else {
+            keepSingleton(detections, 4);
+            keepSingleton(detections, 5);
+            keepSingleton(detections, 6);
+            assignTeamLabels(detections);
+            for (Detection& detection : detections) {
+                if (detection.cls == 4) detection.label = "clock";
+            }
+            keepHighestPerLabel(detections);
+            recognizeText(frame, detections, width, height);
+            std::sort(detections.begin(), detections.end(), [](const Detection& a, const Detection& b) {
+                if (a.label != b.label) return a.label < b.label;
+                return a.confidence > b.confidence;
+            });
+            for (const Detection& detection : detections) {
+                output["detections"].push_back(detectionJson(detection));
+                output["draw_detections"].push_back(detectionJson(detection));
+            }
+            output["reason"] = detections.empty() ? "components_not_detected" : "ok";
+        }
+        const double elapsed_ms = std::chrono::duration<double, std::milli>(
+            std::chrono::steady_clock::now() - start).count();
+        output["stats"] = {
+            {"level2_boxes", detections.size()},
+            {"elapsed_ms", elapsed_ms},
+            {"sample_every_n", sample_every_n_},
+        };
+        av_dict_set(&frame.raw()->metadata, metadata_key_.c_str(), output.dump().c_str(), 0);
+        ++sample_counter_;
+        if (debug_log_every_n_ > 0 && sample_counter_ % (uint64_t)debug_log_every_n_ == 0) {
+            logstream << "scoreboard_two_stage_ocr frame=" << frame_counter_
+                      << " components=" << detections.size()
+                      << " ambiguous=" << (ambiguous ? 1 : 0)
+                      << " elapsed_ms=" << elapsed_ms;
+        }
+        this->sink_->put(frame);
+    }
+
+    static std::shared_ptr<ScoreboardTwoStageOcr> create(NodeCreationInfo& nci) {
+        const Parameters& params = nci.params;
+        auto result = NodeSISO<av::VideoFrame, av::VideoFrame>::template createCommon<ScoreboardTwoStageOcr>(
+            nci.edges, params);
+        for (const char* required : {"level1_engine", "level2_engine", "recognizer_engine", "hwaccel"}) {
+            if (!params.count(required)) throw Error(std::string("scoreboard_two_stage: ") + required + " param required");
+        }
+        result->node_label_ = params.value("name", std::string("<unnamed>"));
+        result->level1_engine_ = params["level1_engine"].get<std::string>();
+        result->level2_engine_ = params["level2_engine"].get<std::string>();
+        result->recognizer_engine_ = params["recognizer_engine"].get<std::string>();
+        result->hwaccel_ = InstanceSharedObjects<HWAccelDevice>::get(nci.instance, params["hwaccel"]);
+        if (params.count("metadata_key")) result->metadata_key_ = params["metadata_key"].get<std::string>();
+        if (params.count("target_fps")) result->target_fps_ = std::max(0.1f, params["target_fps"].get<float>());
+        if (params.count("input_fps")) result->input_fps_ = parseFps(params["input_fps"].get<std::string>());
+        result->sample_every_n_ = std::max(1, (int)std::lround(result->input_fps_ / result->target_fps_));
+        if (params.count("level1_confidence")) result->level1_confidence_ = params["level1_confidence"].get<float>();
+        if (params.count("level2_confidence")) result->level2_confidence_ = params["level2_confidence"].get<float>();
+        if (params.count("reco_conf_thresh")) result->recognition_confidence_ = params["reco_conf_thresh"].get<float>();
+        if (params.count("vertical_padding")) result->vertical_padding_ = std::max(0, params["vertical_padding"].get<int>());
+        if (params.count("max_boxes")) result->max_boxes_ = std::max(1, params["max_boxes"].get<int>());
+        if (params.count("edge_margin")) result->edge_margin_ = std::clamp(params["edge_margin"].get<float>(), 0.0f, 1.0f);
+        if (params.count("edge_margin_px")) result->edge_margin_px_ = std::max(0, params["edge_margin_px"].get<int>());
+        if (params.count("region_x") && params["region_x"].is_array() && params["region_x"].size() == 2) {
+            result->region_x_ = {params["region_x"][0].get<float>(), params["region_x"][1].get<float>()};
+            if (result->region_x_[0] < 0.0f || result->region_x_[1] > 1.0f ||
+                result->region_x_[0] >= result->region_x_[1]) {
+                throw Error("scoreboard_two_stage: region_x must be [start,end] within [0,1]");
+            }
+        }
+        if (params.count("debug_log_every_n")) result->debug_log_every_n_ = std::max(0, params["debug_log_every_n"].get<int>());
+        result->preinitialize();
+        return result;
+    }
+};
+
+DECLNODE(scoreboard_two_stage_ocr, ScoreboardTwoStageOcr)

--- a/src/nodes/neural_net/preprocess/nv12_doctr_preprocess.cu
+++ b/src/nodes/neural_net/preprocess/nv12_doctr_preprocess.cu
@@ -69,3 +69,72 @@ extern "C" __global__ void kNV12_doctr_crop_resize_pad_f32(
     out_nchw[out_idx + 1 * plane] = (g - mean_g) / std_g;
     out_nchw[out_idx + 2 * plane] = (b - mean_b) / std_b;
 }
+extern "C" __global__ void kNV12_scoreboard_letterbox_f32(
+    const uint8_t* __restrict__ y_plane, int y_pitch,
+    const uint8_t* __restrict__ uv_plane, int uv_pitch,
+    float* __restrict__ out_nchw,
+    const int* __restrict__ box_xywh,
+    int dst_h, int dst_w, float pad_value)
+{
+    int dx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int dy = (int)(blockIdx.y * blockDim.y + threadIdx.y);
+    if (dx >= dst_w || dy >= dst_h) return;
+
+    int sx0 = box_xywh[0], sy0 = box_xywh[1];
+    int sw = box_xywh[2], sh = box_xywh[3];
+    int plane = dst_w * dst_h;
+    int out_idx = dy * dst_w + dx;
+    float scale = fminf((float)dst_w / fmaxf(1.0f, (float)sw),
+                        (float)dst_h / fmaxf(1.0f, (float)sh));
+    int content_w = max(1, min(dst_w, (int)floorf((float)sw * scale + 0.5f)));
+    int content_h = max(1, min(dst_h, (int)floorf((float)sh * scale + 0.5f)));
+    int pad_x = (dst_w - content_w) / 2;
+    int pad_y = (dst_h - content_h) / 2;
+
+    float r = pad_value, g = pad_value, b = pad_value;
+    if (dx >= pad_x && dx < pad_x + content_w && dy >= pad_y && dy < pad_y + content_h) {
+        float sx = (float)sx0 + ((float)(dx - pad_x) + 0.5f) * ((float)sw / (float)content_w) - 0.5f;
+        float sy = (float)sy0 + ((float)(dy - pad_y) + 0.5f) * ((float)sh / (float)content_h) - 0.5f;
+        int px = max(sx0, min(sx0 + sw - 1, (int)floorf(sx + 0.5f)));
+        int py = max(sy0, min(sy0 + sh - 1, (int)floorf(sy + 0.5f)));
+        nv12_rgb01_doctr(y_plane, y_pitch, uv_plane, uv_pitch, px, py, r, g, b);
+    }
+    out_nchw[out_idx] = r;
+    out_nchw[out_idx + plane] = g;
+    out_nchw[out_idx + 2 * plane] = b;
+}
+
+extern "C" __global__ void kNV12_scoreboard_letterbox_u8(
+    const uint8_t* __restrict__ y_plane, int y_pitch,
+    const uint8_t* __restrict__ uv_plane, int uv_pitch,
+    uint8_t* __restrict__ out_nchw,
+    const int* __restrict__ box_xywh,
+    int dst_h, int dst_w)
+{
+    int dx = (int)(blockIdx.x * blockDim.x + threadIdx.x);
+    int dy = (int)(blockIdx.y * blockDim.y + threadIdx.y);
+    if (dx >= dst_w || dy >= dst_h) return;
+
+    int sx0 = box_xywh[0], sy0 = box_xywh[1];
+    int sw = box_xywh[2], sh = box_xywh[3];
+    int plane = dst_w * dst_h;
+    int out_idx = dy * dst_w + dx;
+    float scale = fminf((float)dst_w / fmaxf(1.0f, (float)sw),
+                        (float)dst_h / fmaxf(1.0f, (float)sh));
+    int content_w = max(1, min(dst_w, (int)floorf((float)sw * scale + 0.5f)));
+    int content_h = max(1, min(dst_h, (int)floorf((float)sh * scale + 0.5f)));
+    int pad_x = (dst_w - content_w) / 2;
+    int pad_y = (dst_h - content_h) / 2;
+
+    float r = 0.0f, g = 0.0f, b = 0.0f;
+    if (dx >= pad_x && dx < pad_x + content_w && dy >= pad_y && dy < pad_y + content_h) {
+        float sx = (float)sx0 + ((float)(dx - pad_x) + 0.5f) * ((float)sw / (float)content_w) - 0.5f;
+        float sy = (float)sy0 + ((float)(dy - pad_y) + 0.5f) * ((float)sh / (float)content_h) - 0.5f;
+        int px = max(sx0, min(sx0 + sw - 1, (int)floorf(sx + 0.5f)));
+        int py = max(sy0, min(sy0 + sh - 1, (int)floorf(sy + 0.5f)));
+        nv12_rgb01_doctr(y_plane, y_pitch, uv_plane, uv_pitch, px, py, r, g, b);
+    }
+    out_nchw[out_idx] = (uint8_t)floorf(r * 255.0f + 0.5f);
+    out_nchw[out_idx + plane] = (uint8_t)floorf(g * 255.0f + 0.5f);
+    out_nchw[out_idx + 2 * plane] = (uint8_t)floorf(b * 255.0f + 0.5f);
+}

--- a/tests/cpp/test_scoreboard_box_stabilizer.cpp
+++ b/tests/cpp/test_scoreboard_box_stabilizer.cpp
@@ -1,0 +1,174 @@
+#include "nodes/neural_net/ocr/scoreboard_post_process.hpp"
+
+#include <cmath>
+#include <cstdio>
+#include <random>
+
+using scoreboard_post::Box;
+using scoreboard_post::BoxStabilizer;
+using scoreboard_post::PostProcessor;
+
+static int g_failures = 0;
+
+#define CHECK(cond)                                                            \
+    do {                                                                       \
+        if (!(cond)) {                                                         \
+            std::printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond);       \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+#define CHECK_NEAR(a, b, eps)                                                  \
+    do {                                                                       \
+        const double _a = (a), _b = (b);                                       \
+        if (std::fabs(_a - _b) > (eps)) {                                      \
+            std::printf("FAIL %s:%d: %s (%.6f) != %s (%.6f)\n", __FILE__,     \
+                        __LINE__, #a, _a, #b, _b);                             \
+            ++g_failures;                                                      \
+        }                                                                      \
+    } while (0)
+
+static float center_x(const Box& box) { return (box.x1 + box.x2) * 0.5f; }
+static float center_y(const Box& box) { return (box.y1 + box.y2) * 0.5f; }
+
+static void test_overlapping_boxes_are_smoothed() {
+    BoxStabilizer stabilizer(0.25f, 0.5f);
+    const Box first{0.10f, 0.20f, 0.40f, 0.50f};
+    const Box second{0.12f, 0.18f, 0.42f, 0.48f};
+
+    stabilizer.update(first);
+    const auto update = stabilizer.update(second);
+
+    CHECK(update.matched);
+    CHECK(!update.relocated);
+    CHECK_NEAR(update.box.x1, 0.105f, 1e-6);
+    CHECK_NEAR(update.box.y1, 0.195f, 1e-6);
+    CHECK(std::fabs(center_x(update.box) - center_x(first)) <
+          std::fabs(center_x(second) - center_x(first)));
+}
+
+static void test_relocation_resets_without_blending() {
+    BoxStabilizer stabilizer;
+    stabilizer.update({0.05f, 0.05f, 0.20f, 0.20f});
+    const Box relocated{0.70f, 0.65f, 0.95f, 0.90f};
+
+    const auto update = stabilizer.update(relocated);
+
+    CHECK(!update.matched);
+    CHECK(update.relocated);
+    CHECK_NEAR(update.box.x1, relocated.x1, 1e-6);
+    CHECK_NEAR(update.box.y2, relocated.y2, 1e-6);
+}
+
+static void test_random_positions_and_scales_reduce_jitter() {
+    std::mt19937 random(0x51A8u);
+    std::uniform_real_distribution<float> position(0.02f, 0.75f);
+    std::uniform_real_distribution<float> size(0.06f, 0.22f);
+    std::uniform_real_distribution<float> jitter(-0.04f, 0.04f);
+
+    for (int scenario = 0; scenario < 500; ++scenario) {
+        const float width = size(random);
+        const float height = size(random);
+        const float x = std::min(position(random), 0.98f - width);
+        const float y = std::min(position(random), 0.98f - height);
+        const Box anchor{x, y, x + width, y + height};
+        const float dx = jitter(random) * width;
+        const float dy = jitter(random) * height;
+        const Box current{x + dx, y + dy, x + width + dx, y + height + dy};
+
+        BoxStabilizer stabilizer(0.25f, 0.5f);
+        stabilizer.update(anchor);
+        const auto update = stabilizer.update(current);
+
+        CHECK(update.matched);
+        const float raw_motion = std::hypot(center_x(current) - center_x(anchor),
+                                            center_y(current) - center_y(anchor));
+        const float stable_motion = std::hypot(center_x(update.box) - center_x(anchor),
+                                               center_y(update.box) - center_y(anchor));
+        CHECK(stable_motion <= raw_motion + 1e-7f);
+    }
+}
+
+static void test_clear_forgets_previous_layout() {
+    BoxStabilizer stabilizer;
+    stabilizer.update({0.10f, 0.10f, 0.30f, 0.30f});
+    stabilizer.clear();
+    const Box next{0.11f, 0.11f, 0.31f, 0.31f};
+
+    const auto update = stabilizer.update(next);
+
+    CHECK(!update.matched);
+    CHECK(!update.relocated);
+    CHECK_NEAR(update.box.x1, next.x1, 1e-6);
+}
+
+static void test_post_processor_resets_components_on_level1_relocation() {
+    PostProcessor post;
+    post.updateLevel1({0.05f, 0.70f, 0.45f, 0.90f});
+    const Box first_component{0.10f, 0.75f, 0.20f, 0.82f};
+    post.updateComponent("clock", first_component);
+    post.updateComponent("clock", {0.11f, 0.75f, 0.21f, 0.82f});
+
+    const auto relocated = post.updateLevel1({0.55f, 0.05f, 0.95f, 0.25f});
+    const Box new_component{0.60f, 0.10f, 0.70f, 0.17f};
+    const Box output = post.updateComponent("clock", new_component);
+
+    CHECK(relocated.relocated);
+    CHECK_NEAR(output.x1, new_component.x1, 1e-6);
+    CHECK_NEAR(output.y1, new_component.y1, 1e-6);
+}
+
+static void test_level1_horizontal_extent_change_is_not_relocation() {
+    PostProcessor post;
+    post.updateLevel1({0.70f, 0.70f, 0.95f, 0.90f});
+    post.updateComponent("clock", {0.80f, 0.75f, 0.86f, 0.82f});
+    post.updateComponent("clock", {0.81f, 0.75f, 0.87f, 0.82f});
+
+    const auto update = post.updateLevel1({0.40f, 0.70f, 0.95f, 0.90f});
+    const Box current_component{0.82f, 0.75f, 0.88f, 0.82f};
+    const Box output = post.updateComponent("clock", current_component);
+
+    CHECK(!update.relocated);
+    CHECK(output.x1 < current_component.x1);
+    CHECK(output.x2 < current_component.x2);
+}
+
+static void test_level2_crop_is_layout_independent_and_even_aligned() {
+    std::mt19937 random(0xC20Fu);
+    std::uniform_int_distribution<int> frame_width(320, 3840);
+    std::uniform_int_distribution<int> frame_height(180, 2160);
+    std::uniform_real_distribution<float> unit(0.0f, 1.0f);
+
+    for (int scenario = 0; scenario < 500; ++scenario) {
+        const int width = frame_width(random);
+        const int height = frame_height(random) & ~1;
+        const float y1 = unit(random) * (height - 2.0f);
+        const float y2 = y1 + 1.0f + unit(random) * (height - y1 - 1.0f);
+        const Box scorebug{0.0f, y1, (float)width, y2};
+        const auto crop = PostProcessor::level2Crop(scorebug, width, height, 50);
+
+        CHECK(crop[0] == 0);
+        CHECK(crop[1] >= 0);
+        CHECK(crop[1] % 2 == 0);
+        CHECK(crop[2] == width);
+        CHECK(crop[3] > 0);
+        CHECK(crop[3] % 2 == 0);
+        CHECK(crop[1] + crop[3] <= height);
+    }
+}
+
+int main() {
+    test_overlapping_boxes_are_smoothed();
+    test_relocation_resets_without_blending();
+    test_random_positions_and_scales_reduce_jitter();
+    test_clear_forgets_previous_layout();
+    test_post_processor_resets_components_on_level1_relocation();
+    test_level1_horizontal_extent_change_is_not_relocation();
+    test_level2_crop_is_layout_independent_and_even_aligned();
+    if (g_failures == 0) {
+        std::printf("OK: all scoreboard stabilizer tests passed\n");
+        return 0;
+    }
+    std::printf("FAILED: %d check(s)\n", g_failures);
+    return 1;
+}

--- a/tests/cpp/test_scoreboard_box_stabilizer.cpp
+++ b/tests/cpp/test_scoreboard_box_stabilizer.cpp
@@ -47,6 +47,54 @@ static void test_overlapping_boxes_are_smoothed() {
           std::fabs(center_x(second) - center_x(first)));
 }
 
+static void test_third_observation_uses_coordinate_median() {
+    BoxStabilizer stabilizer(0.25f, 0.5f);
+    const Box first{0.10f, 0.20f, 0.40f, 0.50f};
+    const Box second{0.11f, 0.20f, 0.41f, 0.50f};
+    const Box in_track_outlier{0.18f, 0.20f, 0.48f, 0.50f};
+
+    stabilizer.update(first);
+    stabilizer.update(second);
+    const auto update = stabilizer.update(in_track_outlier);
+
+    CHECK(update.matched);
+    CHECK(!update.relocated);
+    // The median observation is the second box, not the outlier.
+    CHECK_NEAR(update.box.x1, 0.104375f, 1e-6);
+    CHECK_NEAR(update.box.x2, 0.404375f, 1e-6);
+}
+
+static void test_isolated_in_track_outlier_is_rejected() {
+    BoxStabilizer stabilizer(0.25f, 0.5f);
+    const Box anchor{0.10f, 0.20f, 0.40f, 0.50f};
+    const Box outlier{0.16f, 0.20f, 0.46f, 0.50f};
+
+    stabilizer.update(anchor);
+    stabilizer.update(anchor);
+    stabilizer.update(anchor);
+    const auto update = stabilizer.update(outlier);
+
+    CHECK(update.matched);
+    CHECK_NEAR(update.box.x1, anchor.x1, 1e-6);
+    CHECK_NEAR(update.box.x2, anchor.x2, 1e-6);
+}
+
+static void test_moderate_sustained_move_has_one_observation_delay() {
+    BoxStabilizer stabilizer(0.25f, 0.5f);
+    const Box anchor{0.10f, 0.20f, 0.30f, 0.40f};
+    const Box moved{0.13f, 0.20f, 0.33f, 0.40f};
+
+    stabilizer.update(anchor);
+    stabilizer.update(anchor);
+    stabilizer.update(anchor);
+    const auto first_moved = stabilizer.update(moved);
+    const auto second_moved = stabilizer.update(moved);
+
+    CHECK_NEAR(first_moved.box.x1, anchor.x1, 1e-6);
+    CHECK(second_moved.box.x1 > anchor.x1);
+    CHECK(second_moved.box.x1 < moved.x1);
+}
+
 static void test_relocation_resets_without_blending() {
     BoxStabilizer stabilizer;
     stabilizer.update({0.05f, 0.05f, 0.20f, 0.20f});
@@ -89,6 +137,35 @@ static void test_random_positions_and_scales_reduce_jitter() {
     }
 }
 
+static void test_random_layouts_reject_single_in_track_outlier() {
+    std::mt19937 random(0x4D3D1A3u);
+    std::uniform_real_distribution<float> position(0.02f, 0.75f);
+    std::uniform_real_distribution<float> size(0.06f, 0.22f);
+    std::uniform_real_distribution<float> x_shift(-0.15f, 0.15f);
+    std::uniform_real_distribution<float> y_shift(-0.05f, 0.05f);
+
+    for (int scenario = 0; scenario < 500; ++scenario) {
+        const float width = size(random);
+        const float height = size(random);
+        const float x = std::min(position(random), 0.98f - width);
+        const float y = std::min(position(random), 0.98f - height);
+        const Box anchor{x, y, x + width, y + height};
+        const float dx = x_shift(random) * width;
+        const float dy = y_shift(random) * height;
+        const Box outlier{x + dx, y + dy, x + width + dx, y + height + dy};
+
+        BoxStabilizer stabilizer(0.25f, 0.5f);
+        stabilizer.update(anchor);
+        stabilizer.update(anchor);
+        stabilizer.update(anchor);
+        const auto update = stabilizer.update(outlier);
+
+        CHECK(update.matched);
+        CHECK_NEAR(center_x(update.box), center_x(anchor), 1e-6);
+        CHECK_NEAR(center_y(update.box), center_y(anchor), 1e-6);
+    }
+}
+
 static void test_clear_forgets_previous_layout() {
     BoxStabilizer stabilizer;
     stabilizer.update({0.10f, 0.10f, 0.30f, 0.30f});
@@ -121,6 +198,8 @@ static void test_post_processor_resets_components_on_level1_relocation() {
 static void test_level1_horizontal_extent_change_is_not_relocation() {
     PostProcessor post;
     post.updateLevel1({0.70f, 0.70f, 0.95f, 0.90f});
+    post.updateLevel1({0.70f, 0.70f, 0.95f, 0.90f});
+    post.updateLevel1({0.70f, 0.70f, 0.95f, 0.90f});
     post.updateComponent("clock", {0.80f, 0.75f, 0.86f, 0.82f});
     post.updateComponent("clock", {0.81f, 0.75f, 0.87f, 0.82f});
 
@@ -129,8 +208,97 @@ static void test_level1_horizontal_extent_change_is_not_relocation() {
     const Box output = post.updateComponent("clock", current_component);
 
     CHECK(!update.relocated);
+    CHECK_NEAR(update.box.x1, 0.70f, 1e-6);
+    CHECK_NEAR(update.box.x2, 0.95f, 1e-6);
     CHECK(output.x1 < current_component.x1);
     CHECK(output.x2 < current_component.x2);
+}
+
+static void test_one_level1_miss_retains_geometry_history() {
+    PostProcessor post;
+    const Box level1{0.70f, 0.70f, 0.95f, 0.90f};
+    const Box anchor{0.80f, 0.75f, 0.86f, 0.82f};
+    const Box current{0.81f, 0.75f, 0.87f, 0.82f};
+    post.updateLevel1(level1);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+
+    post.missLevel1();
+    const auto reacquired = post.updateLevel1(level1);
+    const Box output = post.updateComponent("clock", current);
+
+    CHECK(!reacquired.relocated);
+    CHECK_NEAR(output.x1, anchor.x1, 1e-6);
+    CHECK_NEAR(output.x2, anchor.x2, 1e-6);
+}
+
+static void test_two_level1_misses_clear_geometry_history() {
+    PostProcessor post;
+    const Box level1{0.70f, 0.70f, 0.95f, 0.90f};
+    const Box anchor{0.80f, 0.75f, 0.86f, 0.82f};
+    const Box current{0.81f, 0.75f, 0.87f, 0.82f};
+    post.updateLevel1(level1);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+
+    post.missLevel1();
+    post.missLevel1();
+    post.updateLevel1(level1);
+    const Box output = post.updateComponent("clock", current);
+
+    CHECK_NEAR(output.x1, current.x1, 1e-6);
+    CHECK_NEAR(output.x2, current.x2, 1e-6);
+}
+
+static void test_relocation_after_one_miss_clears_geometry_history() {
+    PostProcessor post;
+    post.updateLevel1({0.70f, 0.70f, 0.95f, 0.90f});
+    const Box anchor{0.80f, 0.75f, 0.86f, 0.82f};
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+
+    post.missLevel1();
+    const auto relocated = post.updateLevel1({0.70f, 0.05f, 0.95f, 0.25f});
+    const Box current{0.80f, 0.10f, 0.86f, 0.17f};
+    const Box output = post.updateComponent("clock", current);
+
+    CHECK(relocated.relocated);
+    CHECK_NEAR(output.x1, current.x1, 1e-6);
+    CHECK_NEAR(output.y1, current.y1, 1e-6);
+}
+
+static void test_one_ambiguous_component_sample_retains_geometry_history() {
+    PostProcessor post;
+    const Box anchor{0.80f, 0.75f, 0.86f, 0.82f};
+    const Box outlier{0.81f, 0.75f, 0.87f, 0.82f};
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+
+    post.missComponents();
+    const Box output = post.updateComponent("clock", outlier);
+
+    CHECK_NEAR(output.x1, anchor.x1, 1e-6);
+    CHECK_NEAR(output.x2, anchor.x2, 1e-6);
+}
+
+static void test_two_ambiguous_component_samples_clear_geometry_history() {
+    PostProcessor post;
+    const Box anchor{0.80f, 0.75f, 0.86f, 0.82f};
+    const Box current{0.81f, 0.75f, 0.87f, 0.82f};
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+    post.updateComponent("clock", anchor);
+
+    post.missComponents();
+    post.missComponents();
+    const Box output = post.updateComponent("clock", current);
+
+    CHECK_NEAR(output.x1, current.x1, 1e-6);
+    CHECK_NEAR(output.x2, current.x2, 1e-6);
 }
 
 static void test_level2_crop_is_layout_independent_and_even_aligned() {
@@ -159,11 +327,20 @@ static void test_level2_crop_is_layout_independent_and_even_aligned() {
 
 int main() {
     test_overlapping_boxes_are_smoothed();
+    test_third_observation_uses_coordinate_median();
+    test_isolated_in_track_outlier_is_rejected();
+    test_moderate_sustained_move_has_one_observation_delay();
     test_relocation_resets_without_blending();
     test_random_positions_and_scales_reduce_jitter();
+    test_random_layouts_reject_single_in_track_outlier();
     test_clear_forgets_previous_layout();
     test_post_processor_resets_components_on_level1_relocation();
     test_level1_horizontal_extent_change_is_not_relocation();
+    test_one_level1_miss_retains_geometry_history();
+    test_two_level1_misses_clear_geometry_history();
+    test_relocation_after_one_miss_clears_geometry_history();
+    test_one_ambiguous_component_sample_retains_geometry_history();
+    test_two_ambiguous_component_samples_clear_geometry_history();
     test_level2_crop_is_layout_independent_and_even_aligned();
     if (g_failures == 0) {
         std::printf("OK: all scoreboard stabilizer tests passed\n");

--- a/tests/test_scoreboard_box_stabilizer.py
+++ b/tests/test_scoreboard_box_stabilizer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEST_CPP = REPO_ROOT / "tests/cpp/test_scoreboard_box_stabilizer.cpp"
+
+
+def test_scoreboard_box_stabilizer(tmp_path: Path) -> None:
+    binary = tmp_path / "test_scoreboard_box_stabilizer"
+    subprocess.run(
+        [
+            "g++",
+            "-std=c++17",
+            "-Wall",
+            "-Wextra",
+            "-Werror",
+            f"-I{REPO_ROOT / 'src'}",
+            str(TEST_CPP),
+            "-o",
+            str(binary),
+        ],
+        check=True,
+    )
+    result = subprocess.run([str(binary)], check=False, capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "OK: all scoreboard stabilizer tests passed" in result.stdout


### PR DESCRIPTION
## What changed

- add a native two-stage scoreboard OCR node with TensorRT stage-1 scorebug detection and stage-2 component detection
- add zero-copy CUDA NV12 preprocessing for the 640x384 gray letterbox and 1024x1024 black letterbox contracts
- extract a shared TensorRT runner and Doctr recognizer so the legacy and two-stage nodes do not duplicate recognition code
- expose the node through pyplumber and support the uint8 stage-2 TensorRT input contract

## Why

The recorder needs to select between the legacy Doctr-first detector and a new two-model detector while retaining the existing Doctr recognition phase. Keeping inference native preserves CUDA frames end-to-end and avoids CPU upload/download steps.

## Validation

- full CUDA, TensorRT, NVCC, DRM/GL pyplumber Docker build on a Tesla T4
- TensorRT contracts verified for 1x3x384x640 float stage 1, 1x3x1024x1024 uint8 stage 2, and batch-48 Doctr recognition
- complete 95-second BBL run with stable component bboxes and OCR metadata
- legacy Doctr backend smoke-tested after the shared recognizer extraction
