### PR TITLE
Fix GIL/busy_-lock deadlock in NodeGroup.sortedNodes

### DIFF
--- a/src/avplumber_pybind.cpp
+++ b/src/avplumber_pybind.cpp
@@ -648,8 +648,19 @@ PYBIND11_MODULE(_avplumber, m) {
         .def("restartNodes", &NodeGroup::restartNodes,
              py::call_guard<py::gil_scoped_release>())
         .def_property_readonly("sortedNodes", [](NodeGroup &ng) -> py::list {
+            // Same GIL-release rationale as startNodes/stopNodes/restartNodes
+            // above: sortedNodes() takes the group's busy_ lock, which is held
+            // across node creation on GM threads while they reacquire the GIL
+            // (NodeGroup::doWithNodes -> NodeWrapper::createNode). Holding the
+            // GIL here while waiting for that lock is a lock-order inversion
+            // that deadlocks against those threads.
+            std::list<std::weak_ptr<NodeWrapper>> nodes_copy;
+            {
+                py::gil_scoped_release release;
+                nodes_copy = ng.sortedNodes();
+            }
             py::list sorted_nodes;
-            for (auto &weak_node: ng.sortedNodes()) {
+            for (auto &weak_node: nodes_copy) {
                 auto node = weak_node.lock();
                 if (node) {
                     sorted_nodes.append(node);

--- a/src/avplumber_pybind.cpp
+++ b/src/avplumber_pybind.cpp
@@ -608,15 +608,27 @@ PYBIND11_MODULE(_avplumber, m) {
         .def(py::init<>())
         .def("addNode", [](NodeManager &nm, py::dict &parameters, bool early_create=false, bool start=false, py::object node_obj=py::none()) {
             Parameters json_parameters = pyjson::to_json(parameters);
+            // Same GIL-release rationale as the NodeGroup bindings below:
+            // createNode takes the manager's and the target group's busy_
+            // locks, and createNode()/start() reacquire the GIL for python
+            // nodes, so holding the GIL across them deadlocks against GM
+            // threads. setPythonNodeObject must keep the GIL (py::object).
             if (node_obj.is_none()) {
+                py::gil_scoped_release release;
                 return nm.createNode(json_parameters, early_create, start);
             }
-            auto result = nm.createNode(json_parameters, false, false);
+            std::shared_ptr<NodeWrapper> result;
+            {
+                py::gil_scoped_release release;
+                result = nm.createNode(json_parameters, false, false);
+            }
             result->setPythonNodeObject(node_obj);
             if (early_create) {
+                py::gil_scoped_release release;
                 result->createNode();
             }
             if (start) {
+                py::gil_scoped_release release;
                 result->start();
             }
             return result;
@@ -653,7 +665,9 @@ PYBIND11_MODULE(_avplumber, m) {
             // across node creation on GM threads while they reacquire the GIL
             // (NodeGroup::doWithNodes -> NodeWrapper::createNode). Holding the
             // GIL here while waiting for that lock is a lock-order inversion
-            // that deadlocks against those threads.
+            // that deadlocks against those threads. sortedNodes() returns a
+            // copy made under busy_, so iterating it below without the lock
+            // is safe against concurrent graph mutation.
             std::list<std::weak_ptr<NodeWrapper>> nodes_copy;
             {
                 py::gil_scoped_release release;

--- a/src/graph_mgmt.cpp
+++ b/src/graph_mgmt.cpp
@@ -599,10 +599,10 @@ bool NodeManager::nodeExists(const std::string& name) {
 }
 
 
-const std::list<NodeGroup::Item>& NodeGroup::sortedNodes() {
+std::list<NodeGroup::Item> NodeGroup::sortedNodes() {
     auto lock = getLock();
     if (!is_sorted_) sort();
-    return sorted_nodes_;
+    return sorted_nodes_; // copied into the return value before lock is released
 }
 
 
@@ -809,6 +809,7 @@ void NodeGroup::sort() {
     {
         auto lock = getLock();
         NodeGroupUtils::sort(sorted_nodes_, nodes_);
+        is_sorted_ = true;
     }
 }
 

--- a/src/graph_mgmt.hpp
+++ b/src/graph_mgmt.hpp
@@ -197,7 +197,9 @@ public:
     void restartNodes() {
         goToState(State::RESTART);
     }
-    const std::list<Item>& sortedNodes();
+    // Returns a copy taken under busy_ so callers may iterate without the
+    // lock; the live list is rebuilt by sort() and cleared by add().
+    std::list<Item> sortedNodes();
 };
 
 class NodeManager: public std::enable_shared_from_this<NodeManager> {


### PR DESCRIPTION
NodeGroup::sortedNodes() takes the group's recursive busy_ lock. NodeGroup::doWithNodes() holds that same lock for the whole node- creation/start loop, and each iteration reacquires the GIL to call into Python node constructors (NodeWrapper::createNode). The sortedNodes property binding called into C++ while still holding the GIL, so a Python caller (e.g. a periodic health-check reading group(...).sortedNodes) could block waiting for busy_ while a GM thread mid-construction blocked waiting for the GIL - AB-BA deadlock, freezing the whole graph.

startNodes/stopNodes/restartNodes already release the GIL for the same reason; sortedNodes was missed.